### PR TITLE
Feat/GitHub workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,45 @@
+name: 🐛 Bug Report
+description: Signaler un bug ou un comportement inattendu
+labels: ['bug', 'awaiting triage']
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Décris le bug de manière claire et concise.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Étapes pour reproduire
+      description: Comment reproduire le bug ?
+      placeholder: |
+        1. Aller sur '...'
+        2. Cliquer sur '...'
+        3. Observer l'erreur
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Comportement attendu
+      description: Que devrait-il se passer normalement ?
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Contexte additionnel
+      description: Logs, captures d'écran, ou toute autre information utile.
+
+  - type: checkboxes
+    id: existing
+    attributes:
+      label: Vérification
+      options:
+        - label: J'ai vérifié que cette issue n'existe pas déjà.
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,40 @@
+name: ✨ Feature Request
+description: Proposer une nouvelle fonctionnalité
+labels: ['enhancement', 'awaiting triage']
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Décris la fonctionnalité souhaitée de manière claire et concise.
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problème à résoudre
+      description: Cette demande est-elle liée à un problème ? Si oui, décris-le.
+      placeholder: Je suis bloqué quand [...]
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Solution envisagée
+      description: Décris comment tu imagines que ça devrait fonctionner.
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Contexte additionnel
+      description: Captures d'écran, références, ou toute autre information utile.
+
+  - type: checkboxes
+    id: existing
+    attributes:
+      label: Vérification
+      options:
+        - label: J'ai vérifié que cette feature n'a pas déjà été demandée.
+          required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,20 +1,20 @@
-## Quoi ?
+## Description
 
-<!-- Ce que cette PR change -->
+<!-- Décris les changements apportés et pourquoi -->
+<!-- Si cette PR corrige une issue, lie-la ici -->
 
-## Pourquoi ?
-
-<!-- La raison du changement -->
+- Fixes #XXXX
 
 ## Comment tester ?
 
-<!-- Commandes à lancer pour vérifier que ça marche -->
+<!-- Décris comment vérifier que ça fonctionne -->
 
 ```bash
-# ex:
 docker compose up -d
 pytest tests/
 ```
+
+## Captures / Logs (si applicable)
 
 ## Checklist
 
@@ -22,3 +22,5 @@ pytest tests/
 - [ ] `pytest` passe sans erreur
 - [ ] Pas de secret dans le code
 - [ ] Les nouvelles routes ont `@login_required` + `@role_required`
+- [ ] Les inputs sont validés côté serveur
+- [ ] Les formulaires ont un token CSRF


### PR DESCRIPTION
## Quoi ?

Ajout des templates GitHub pour standardiser la collaboration :
- Template de Pull Request
- Issue templates (bug report, feature request) au format GitHub Forms

## Pourquoi ?

Uniformiser les contributions et faciliter le triage des issues/PRs dans le cadre du projet académique avec 4 personnes.

## Comment tester ?

Ouvrir une nouvelle issue sur GitHub → vérifier que le choix entre Bug Report et Feature Request apparaît.
Ouvrir une nouvelle PR → vérifier que le template se pré-remplit.

## Checklist

- [x] `flake8` passe sans erreur
- [x] `pytest` passe sans erreur
- [x] Pas de secret dans le code
- [ ] Les nouvelles routes ont `@login_required` + `@role_required` — N/A (pas de code applicatif)
