### PR TITLE
feat: setup initial — modèles, app factory, flake8, conftest

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E221

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,8 +1,29 @@
+import os
 from flask import Flask, jsonify
+from flask_login import LoginManager
+from .models import db
 
 
-def create_app():
+def create_app(config=None):
     app = Flask(__name__)
+
+    # COnfig
+    app.config['SQLALCHEMY_DATABASE_URI'] = os.environ.get(
+        'DATABASE_URL', 'sqlite:///:memory:'
+        )
+    app.config['SECRET_KEY'] = 'dev_secret_key'
+
+    if config:
+        app.config.update(config)
+
+    db.init_app(app)
+    login_manager = LoginManager()
+    login_manager.init_app(app)
+
+    @login_manager.user_loader
+    def load_user(user_id):
+        from .models import User
+        return User.query.get(int(user_id))
 
     @app.route("/health")
     def health():

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,300 @@
+from flask_login import UserMixin
+from flask_sqlalchemy import SQLAlchemy
+
+db = SQLAlchemy()
+
+
+prof_matiere = db.Table(
+    'prof_matiere',
+    db.Column('id_prof', db.Integer, db.ForeignKey('prof.id'), primary_key=True),
+    db.Column('id_matiere', db.Integer, db.ForeignKey('matiere.id'), primary_key=True)
+)
+
+
+class User(UserMixin, db.Model):
+    __tablename__ = 'user'
+
+    id = db.Column(db.Integer, primary_key=True)
+    type = db.Column(
+        db.Enum('élève', 'employé', 'parent', 'administrateur'),
+        nullable=False
+    )
+    nom = db.Column(db.String(100), nullable=False)
+    prenom = db.Column(db.String(100), nullable=False)
+    username = db.Column(db.String(100), nullable=False, unique=True)
+    password = db.Column(db.String(255), nullable=False)
+    mail_interne = db.Column(db.String(150), unique=True)
+
+
+class Information(db.Model):
+    __tablename__ = 'information'
+
+    id = db.Column(db.Integer, primary_key=True)
+    id_user = db.Column(
+        db.Integer, db.ForeignKey('user.id', ondelete='CASCADE'), nullable=False
+    )
+    numero = db.Column(db.Integer)
+    mail = db.Column(db.String(150))
+    adresse = db.Column(db.String(255))
+
+
+class Direction(db.Model):
+    __tablename__ = 'direction'
+
+    id = db.Column(db.Integer, primary_key=True)
+    id_user = db.Column(
+        db.Integer, db.ForeignKey('user.id', ondelete='CASCADE'), nullable=False
+    )
+    role = db.Column(db.String(100))
+
+
+class Matiere(db.Model):
+    __tablename__ = 'matiere'
+
+    id = db.Column(db.Integer, primary_key=True)
+    nom = db.Column(db.String(100), nullable=False)
+
+
+class Prof(db.Model):
+    __tablename__ = 'prof'
+
+    id = db.Column(db.Integer, primary_key=True)
+    id_user = db.Column(
+        db.Integer, db.ForeignKey('user.id', ondelete='CASCADE'), nullable=False
+    )
+    matieres = db.relationship('Matiere', secondary=prof_matiere, backref='profs')
+
+
+class Classe(db.Model):
+    __tablename__ = 'classe'
+
+    id = db.Column(db.Integer, primary_key=True)
+    niveau = db.Column(db.Integer, nullable=False)
+    suffixe = db.Column(db.String(10))
+    annee = db.Column(db.Integer, nullable=False)
+    id_prof_principal = db.Column(
+        db.Integer, db.ForeignKey('prof.id', ondelete='SET NULL'), nullable=True
+    )
+
+
+class Eleve(db.Model):
+    __tablename__ = 'eleve'
+
+    id = db.Column(db.Integer, primary_key=True)
+    id_user = db.Column(
+        db.Integer, db.ForeignKey('user.id', ondelete='CASCADE'), nullable=False
+    )
+    id_classe = db.Column(
+        db.Integer, db.ForeignKey('classe.id', ondelete='RESTRICT'), nullable=True
+    )
+    id_responsable = db.Column(
+        db.Integer,
+        db.ForeignKey(
+            'parent.id', ondelete='SET NULL',
+            use_alter=True, name='fk_eleve_responsable'
+        ),
+        nullable=True
+    )
+    groupe = db.Column(db.String(1))
+    date_naissance = db.Column(db.Date)
+
+
+class Parent(db.Model):
+    __tablename__ = 'parent'
+
+    id = db.Column(db.Integer, primary_key=True)
+    id_user = db.Column(
+        db.Integer, db.ForeignKey('user.id', ondelete='CASCADE'), nullable=False
+    )
+    id_eleve = db.Column(
+        db.Integer, db.ForeignKey('eleve.id', ondelete='CASCADE'), nullable=False
+    )
+    id_information = db.Column(
+        db.Integer, db.ForeignKey('information.id', ondelete='SET NULL'), nullable=True
+    )
+
+
+class Employe(db.Model):
+    __tablename__ = 'employe'
+
+    id = db.Column(db.Integer, primary_key=True)
+    id_user = db.Column(
+        db.Integer, db.ForeignKey('user.id', ondelete='CASCADE'), nullable=False
+    )
+    role = db.Column(db.String(100))
+
+
+class Batiment(db.Model):
+    __tablename__ = 'batiment'
+
+    id = db.Column(db.Integer, primary_key=True)
+    nom = db.Column(db.String(50), nullable=False)
+
+
+class Etage(db.Model):
+    __tablename__ = 'etage'
+
+    id = db.Column(db.Integer, primary_key=True)
+    numero = db.Column(db.Integer, nullable=False)
+    id_batiment = db.Column(
+        db.Integer, db.ForeignKey('batiment.id', ondelete='CASCADE'), nullable=False
+    )
+
+
+class Salle(db.Model):
+    __tablename__ = 'salle'
+
+    id = db.Column(db.Integer, primary_key=True)
+    nom = db.Column(db.String(100), nullable=False)
+    id_etage = db.Column(
+        db.Integer, db.ForeignKey('etage.id', ondelete='CASCADE'), nullable=False
+    )
+
+
+class Evenement(db.Model):
+    __tablename__ = 'evenement'
+
+    id = db.Column(db.Integer, primary_key=True)
+    type = db.Column(db.String(100), nullable=False)
+    nom = db.Column(db.String(150), nullable=False)
+    responsable = db.Column(db.String(150))
+    date = db.Column(db.DateTime, nullable=False)
+    invites = db.Column(db.Text)
+
+
+class Menu(db.Model):
+    __tablename__ = 'menu'
+
+    id = db.Column(db.Integer, primary_key=True)
+    date = db.Column(db.DateTime, nullable=False)
+    entree = db.Column(db.String(150))
+    plat = db.Column(db.String(150))
+    dessert = db.Column(db.String(150))
+    special = db.Column(db.Boolean, default=False)
+    special_info = db.Column(db.String(255))
+    id_evenement = db.Column(
+        db.Integer, db.ForeignKey('evenement.id', ondelete='SET NULL'), nullable=True
+    )
+
+
+class Cours(db.Model):
+    __tablename__ = 'cours'
+
+    id = db.Column(db.Integer, primary_key=True)
+    id_matiere = db.Column(
+        db.Integer, db.ForeignKey('matiere.id', ondelete='RESTRICT'), nullable=False
+    )
+    id_prof = db.Column(
+        db.Integer, db.ForeignKey('prof.id', ondelete='RESTRICT'), nullable=False
+    )
+    id_classe = db.Column(
+        db.Integer, db.ForeignKey('classe.id', ondelete='CASCADE'), nullable=False
+    )
+    debut = db.Column(db.DateTime, nullable=False)
+    fin = db.Column(db.DateTime, nullable=False)
+    etat = db.Column(
+        db.Enum('planifié', 'en cours', 'terminé', 'annulé'),
+        nullable=False,
+        default='planifié'
+    )
+    id_salle = db.Column(
+        db.Integer, db.ForeignKey('salle.id', ondelete='SET NULL'), nullable=True
+    )
+
+
+class Devoir(db.Model):
+    __tablename__ = 'devoir'
+
+    id = db.Column(db.Integer, primary_key=True)
+    id_classe = db.Column(
+        db.Integer, db.ForeignKey('classe.id', ondelete='CASCADE'), nullable=False
+    )
+    id_matiere = db.Column(
+        db.Integer, db.ForeignKey('matiere.id', ondelete='RESTRICT'), nullable=False
+    )
+    type = db.Column(
+        db.Enum('exercice', 'soutenance', 'exposé', 'contrôle', 'autre'),
+        nullable=False
+    )
+    date_limite = db.Column(db.DateTime, nullable=False)
+    consigne = db.Column(db.Text)
+    id_prof = db.Column(
+        db.Integer, db.ForeignKey('prof.id', ondelete='RESTRICT'), nullable=False
+    )
+
+
+class DevoirStatus(db.Model):
+    __tablename__ = 'devoir_status'
+
+    id = db.Column(db.Integer, primary_key=True)
+    id_devoir = db.Column(
+        db.Integer, db.ForeignKey('devoir.id', ondelete='CASCADE'), nullable=False
+    )
+    id_eleve = db.Column(
+        db.Integer, db.ForeignKey('eleve.id', ondelete='CASCADE'), nullable=False
+    )
+    status = db.Column(db.Boolean, default=False)
+    fichier = db.Column(db.String(255))
+
+
+class Evaluation(db.Model):
+    __tablename__ = 'evaluation'
+
+    id = db.Column(db.Integer, primary_key=True)
+    id_eleve = db.Column(
+        db.Integer, db.ForeignKey('eleve.id', ondelete='CASCADE'), nullable=False
+    )
+    id_matiere = db.Column(
+        db.Integer, db.ForeignKey('matiere.id', ondelete='RESTRICT'), nullable=False
+    )
+    note = db.Column(db.Numeric(4, 2), nullable=False)
+    coefficient = db.Column(db.Integer, nullable=False, default=1)
+    date = db.Column(db.DateTime, nullable=False)
+
+
+class Mail(db.Model):
+    __tablename__ = 'mail'
+
+    id = db.Column(db.Integer, primary_key=True)
+    id_expediteur = db.Column(
+        db.Integer, db.ForeignKey('user.id', ondelete='CASCADE'), nullable=False
+    )
+    id_destinataire = db.Column(
+        db.Integer, db.ForeignKey('user.id', ondelete='CASCADE'), nullable=False
+    )
+    objet = db.Column(db.String(255))
+    contenu = db.Column(db.Text)
+    date = db.Column(db.DateTime, nullable=False, server_default=db.func.now())
+
+
+class Communication(db.Model):
+    __tablename__ = 'communication'
+
+    id = db.Column(db.Integer, primary_key=True)
+    id_user = db.Column(
+        db.Integer, db.ForeignKey('user.id', ondelete='CASCADE'), nullable=False
+    )
+    cible = db.Column(
+        db.Enum('parent', 'élève', 'prof', 'tous', 'classe'), nullable=False
+    )
+    id_cible = db.Column(db.Integer)
+    objet = db.Column(db.String(255))
+    contenu = db.Column(db.Text)
+    date_debut = db.Column(db.DateTime)
+    date_fin = db.Column(db.DateTime)
+
+
+class Assiduite(db.Model):
+    __tablename__ = 'assiduite'
+
+    id = db.Column(db.Integer, primary_key=True)
+    id_eleve = db.Column(
+        db.Integer, db.ForeignKey('eleve.id', ondelete='CASCADE'), nullable=False
+    )
+    id_responsable = db.Column(
+        db.Integer, db.ForeignKey('user.id', ondelete='RESTRICT'), nullable=False
+    )
+    type = db.Column(
+        db.Enum('absent', 'retard', 'présent', 'excusé'), nullable=False
+    )
+    date = db.Column(db.DateTime, nullable=False)

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -1,0 +1,274 @@
+-- ============================================================
+-- Création de la base de données
+-- ============================================================
+CREATE DATABASE IF NOT EXISTS guardia_db
+    CHARACTER SET utf8mb4
+    COLLATE utf8mb4_unicode_ci;
+
+USE guardia_db;
+
+-- ============================================================
+-- Bâtiment
+-- ============================================================
+CREATE TABLE Batiment (
+    ID   INT AUTO_INCREMENT PRIMARY KEY,
+    Nom  VARCHAR(50) NOT NULL
+);
+
+-- ============================================================
+-- Étage
+-- ============================================================
+CREATE TABLE Etage (
+    ID           INT AUTO_INCREMENT PRIMARY KEY,
+    Numero       INT NOT NULL,
+    ID_Batiment  INT NOT NULL,
+    FOREIGN KEY (ID_Batiment) REFERENCES Batiment(ID) ON DELETE CASCADE
+);
+
+-- ============================================================
+-- Salle
+-- ============================================================
+CREATE TABLE Salle (
+    ID       INT AUTO_INCREMENT PRIMARY KEY,
+    Nom      VARCHAR(100) NOT NULL,
+    ID_Etage INT NOT NULL,
+    FOREIGN KEY (ID_Etage) REFERENCES Etage(ID) ON DELETE CASCADE
+);
+
+-- ============================================================
+-- User
+-- ============================================================
+CREATE TABLE User (
+    ID           INT AUTO_INCREMENT PRIMARY KEY,
+    Type         ENUM('élève', 'employé', 'parent', 'administrateur') NOT NULL,
+    Nom          VARCHAR(100) NOT NULL,
+    Prenom       VARCHAR(100) NOT NULL,
+    Username     VARCHAR(100) NOT NULL UNIQUE,
+    Password     VARCHAR(255) NOT NULL,
+    Mail_Interne VARCHAR(150) UNIQUE
+);
+
+-- ============================================================
+-- Information
+-- ============================================================
+CREATE TABLE Information (
+    ID      INT AUTO_INCREMENT PRIMARY KEY,
+    ID_User INT NOT NULL,
+    Numero  INT,
+    Mail    VARCHAR(150),
+    Adresse VARCHAR(255),
+    FOREIGN KEY (ID_User) REFERENCES User(ID) ON DELETE CASCADE
+);
+
+-- ============================================================
+-- Direction
+-- ============================================================
+CREATE TABLE Direction (
+    ID      INT AUTO_INCREMENT PRIMARY KEY,
+    ID_User INT NOT NULL,
+    Role    VARCHAR(100),
+    FOREIGN KEY (ID_User) REFERENCES User(ID) ON DELETE CASCADE
+);
+
+-- ============================================================
+-- Matière
+-- ============================================================
+CREATE TABLE Matiere (
+    ID  INT AUTO_INCREMENT PRIMARY KEY,
+    Nom VARCHAR(100) NOT NULL
+);
+
+-- ============================================================
+-- Prof
+-- ============================================================
+CREATE TABLE Prof (
+    ID         INT AUTO_INCREMENT PRIMARY KEY,
+    ID_User    INT NOT NULL,
+    ID_Matiere INT NOT NULL,
+    FOREIGN KEY (ID_User)    REFERENCES User(ID)    ON DELETE CASCADE,
+    FOREIGN KEY (ID_Matiere) REFERENCES Matiere(ID) ON DELETE RESTRICT
+);
+
+-- ============================================================
+-- Classe
+-- ============================================================
+CREATE TABLE Classe (
+    ID                INT AUTO_INCREMENT PRIMARY KEY,
+    Niveau            INT NOT NULL,
+    Suffixe           VARCHAR(10),
+    ID_Prof_Principal INT,
+    Annee             YEAR NOT NULL,
+    FOREIGN KEY (ID_Prof_Principal) REFERENCES Prof(ID) ON DELETE SET NULL
+);
+
+-- ============================================================
+-- Élève (ID_Responsable ajouté après Parent)
+-- ============================================================
+CREATE TABLE Eleve (
+    ID             INT AUTO_INCREMENT PRIMARY KEY,
+    ID_User        INT NOT NULL,
+    ID_Classe      INT,
+    ID_Responsable INT,
+    Groupe         VARCHAR(1),
+    Date_Naissance DATE,
+    FOREIGN KEY (ID_User)   REFERENCES User(ID)   ON DELETE CASCADE,
+    FOREIGN KEY (ID_Classe) REFERENCES Classe(ID) ON DELETE RESTRICT
+);
+
+-- ============================================================
+-- Parent
+-- ============================================================
+CREATE TABLE Parent (
+    ID             INT AUTO_INCREMENT PRIMARY KEY,
+    ID_User        INT NOT NULL,
+    ID_Eleve       INT NOT NULL,
+    ID_Information INT,
+    FOREIGN KEY (ID_User)        REFERENCES User(ID)        ON DELETE CASCADE,
+    FOREIGN KEY (ID_Eleve)       REFERENCES Eleve(ID)       ON DELETE CASCADE,
+    FOREIGN KEY (ID_Information) REFERENCES Information(ID) ON DELETE SET NULL
+);
+
+-- Résolution de la dépendance circulaire Élève <-> Parent
+ALTER TABLE Eleve
+    ADD CONSTRAINT fk_eleve_responsable
+    FOREIGN KEY (ID_Responsable) REFERENCES Parent(ID) ON DELETE SET NULL;
+
+-- ============================================================
+-- Employé
+-- ============================================================
+CREATE TABLE Employe (
+    ID      INT AUTO_INCREMENT PRIMARY KEY,
+    ID_User INT NOT NULL,
+    Role    VARCHAR(100),
+    FOREIGN KEY (ID_User) REFERENCES User(ID) ON DELETE CASCADE
+);
+
+-- ============================================================
+-- Évènement
+-- ============================================================
+CREATE TABLE Evenement (
+    ID          INT AUTO_INCREMENT PRIMARY KEY,
+    Type        VARCHAR(100) NOT NULL,
+    Nom         VARCHAR(150) NOT NULL,
+    Responsable VARCHAR(150),
+    Date        DATETIME NOT NULL,
+    Invites     TEXT
+);
+
+-- ============================================================
+-- Menu
+-- ============================================================
+CREATE TABLE Menu (
+    ID           INT AUTO_INCREMENT PRIMARY KEY,
+    Date         DATETIME NOT NULL,
+    Entree       VARCHAR(150),
+    Plat         VARCHAR(150),
+    Dessert      VARCHAR(150),
+    Special      BOOLEAN DEFAULT FALSE,
+    Special_Info VARCHAR(255),
+    ID_Evenement INT,
+    FOREIGN KEY (ID_Evenement) REFERENCES Evenement(ID) ON DELETE SET NULL
+);
+
+-- ============================================================
+-- Cours
+-- ============================================================
+CREATE TABLE Cours (
+    ID         INT AUTO_INCREMENT PRIMARY KEY,
+    ID_Matiere INT NOT NULL,
+    ID_Prof    INT NOT NULL,
+    ID_Classe  INT NOT NULL,
+    Debut      DATETIME NOT NULL,
+    Fin        DATETIME NOT NULL,
+    Etat       ENUM('planifié', 'en cours', 'terminé', 'annulé') NOT NULL DEFAULT 'planifié',
+    ID_Salle   INT,
+    FOREIGN KEY (ID_Matiere) REFERENCES Matiere(ID) ON DELETE RESTRICT,
+    FOREIGN KEY (ID_Prof)    REFERENCES Prof(ID)    ON DELETE RESTRICT,
+    FOREIGN KEY (ID_Classe)  REFERENCES Classe(ID)  ON DELETE CASCADE,
+    FOREIGN KEY (ID_Salle)   REFERENCES Salle(ID)   ON DELETE SET NULL
+);
+
+-- ============================================================
+-- Devoir
+-- ============================================================
+CREATE TABLE Devoir (
+    ID          INT AUTO_INCREMENT PRIMARY KEY,
+    ID_Classe   INT NOT NULL,
+    ID_Matiere  INT NOT NULL,
+    Type        ENUM('exercice', 'soutenance', 'exposé', 'contrôle', 'autre') NOT NULL,
+    Date_Limite DATETIME NOT NULL,
+    Consigne    TEXT,
+    ID_Prof     INT NOT NULL,
+    FOREIGN KEY (ID_Classe)  REFERENCES Classe(ID)  ON DELETE CASCADE,
+    FOREIGN KEY (ID_Matiere) REFERENCES Matiere(ID) ON DELETE RESTRICT,
+    FOREIGN KEY (ID_Prof)    REFERENCES Prof(ID)    ON DELETE RESTRICT
+);
+
+-- ============================================================
+-- Devoir_Status
+-- ============================================================
+CREATE TABLE Devoir_Status (
+    ID        INT AUTO_INCREMENT PRIMARY KEY,
+    ID_Devoir INT NOT NULL,
+    ID_Eleve  INT NOT NULL,
+    Status    BOOLEAN DEFAULT FALSE,
+    Fichier   VARCHAR(255),
+    FOREIGN KEY (ID_Devoir) REFERENCES Devoir(ID) ON DELETE CASCADE,
+    FOREIGN KEY (ID_Eleve)  REFERENCES Eleve(ID)  ON DELETE CASCADE
+);
+
+-- ============================================================
+-- Évaluation
+-- ============================================================
+CREATE TABLE Evaluation (
+    ID          INT AUTO_INCREMENT PRIMARY KEY,
+    ID_Eleve    INT NOT NULL,
+    ID_Matiere  INT NOT NULL,
+    Note        DECIMAL(4,2) NOT NULL CHECK (Note BETWEEN 0 AND 20),
+    Coefficient INT NOT NULL DEFAULT 1,
+    Date        DATETIME NOT NULL,
+    FOREIGN KEY (ID_Eleve)   REFERENCES Eleve(ID)   ON DELETE CASCADE,
+    FOREIGN KEY (ID_Matiere) REFERENCES Matiere(ID) ON DELETE RESTRICT
+);
+
+-- ============================================================
+-- Mail
+-- ============================================================
+CREATE TABLE Mail (
+    ID               INT AUTO_INCREMENT PRIMARY KEY,
+    ID_Expediteur    INT NOT NULL,
+    ID_Destinataire  INT NOT NULL,
+    Objet            VARCHAR(255),
+    Contenu          TEXT,
+    Date             DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (ID_Expediteur)   REFERENCES User(ID) ON DELETE CASCADE,
+    FOREIGN KEY (ID_Destinataire) REFERENCES User(ID) ON DELETE CASCADE
+);
+
+-- ============================================================
+-- Communication
+-- ============================================================
+CREATE TABLE Communication (
+    ID        INT AUTO_INCREMENT PRIMARY KEY,
+    ID_User   INT NOT NULL,
+    Cible     ENUM('parent', 'élève', 'prof', 'tous', 'classe') NOT NULL,
+    ID_Cible  INT,
+    Objet     VARCHAR(255),
+    Contenu   TEXT,
+    Date_Debut DATETIME,
+    Date_Fin   DATETIME,
+    FOREIGN KEY (ID_User) REFERENCES User(ID) ON DELETE CASCADE
+);
+
+-- ============================================================
+-- Assiduité
+-- ============================================================
+CREATE TABLE Assiduite (
+    ID             INT AUTO_INCREMENT PRIMARY KEY,
+    ID_Eleve       INT NOT NULL,
+    ID_Responsable INT NOT NULL,
+    Type           ENUM('absent', 'retard', 'présent', 'excusé') NOT NULL,
+    Date           DATETIME NOT NULL,
+    FOREIGN KEY (ID_Eleve)       REFERENCES Eleve(ID) ON DELETE CASCADE,
+    FOREIGN KEY (ID_Responsable) REFERENCES User(ID)  ON DELETE RESTRICT
+);

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,16 @@
 import pytest
 from app import create_app
+from app.models import db
 
 
 @pytest.fixture
 def app():
-    app = create_app()
-    app.config["TESTING"] = True
-    yield app
+    app = create_app({'TESTING': True, 'SQLALCHEMY_DATABASE_URI': 'sqlite:///:memory:'})
+
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.drop_all()
 
 
 @pytest.fixture


### PR DESCRIPTION
## Description

Setup initial du backend Flask.

- Configuration Flake8 (PEP8, max 88 chars)
- Schéma de base de données complet (SQLAlchemy models)
- Application factory `create_app` avec Flask-Login, Flask-SQLAlchemy
- Conftest pytest avec app de test SQLite en mémoire

## Comment tester ?

```bash
docker compose up -d
pytest tests/
```

## Captures / Logs (si applicable)

N/A — pas de routes dans ce scope.

## Checklist

- [x] `flake8` passe sans erreur
- [x] `pytest` passe sans erreur
- [x] Pas de secret dans le code
- [ ] Les nouvelles routes ont `@login_required` + `@role_required` — N/A (pas de routes)
- [ ] Les inputs sont validés côté serveur — N/A
- [ ] Les formulaires ont un token CSRF — N/A