### PR TITLE
feat: gestion des comptes utilisateurs (CRUD admin)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ Thumbs.db
 # local only
 CLAUDE.md
 Intranet Features.md
+TODO.md

--- a/README.md
+++ b/README.md
@@ -96,11 +96,14 @@ docker compose down
 # Arrêter et supprimer les volumes (reset BDD)
 docker compose down -v
 
-# Lancer les tests
-pytest tests/
+# Lancer les tests + linting (commande complète)
+flake8 app/ tests/ && pytest tests/ -v
 
-# Lancer le linting
-flake8 app/
+# Lancer les tests seuls
+pytest tests/ -v
+
+# Lancer le linting seul
+flake8 app/ tests/
 ```
 
 ---

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -75,4 +75,7 @@ def create_app(config=None):
 
     from .auth import auth_bp
     app.register_blueprint(auth_bp, url_prefix='/auth')
+
+    from .admin import admin_bp
+    app.register_blueprint(admin_bp, url_prefix='/admin')
     return app

--- a/app/admin/__init__.py
+++ b/app/admin/__init__.py
@@ -1,0 +1,5 @@
+from flask import Blueprint
+
+admin_bp = Blueprint('admin', __name__)
+
+from . import routes  # noqa: F401, E402

--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -1,0 +1,36 @@
+from flask import request, jsonify
+from flask_login import login_required
+from . import admin_bp
+from ..models import User
+from ..decorators import role_required
+
+
+@admin_bp.get('/users')
+@login_required
+@role_required('administrateur')
+def list_users():
+    type_filter = request.args.get('type', '').strip()
+    search = request.args.get('search', '').strip()
+
+    query = User.query
+
+    if type_filter:
+        query = query.filter(User.type == type_filter)
+
+    if search:
+        query = query.filter(
+            (User.nom.ilike(f'%{search}%')) |
+            (User.prenom.ilike(f'%{search}%')) |
+            (User.username.ilike(f'%{search}%'))
+        )
+
+    users = query.order_by(User.nom, User.prenom).all()
+
+    return jsonify([{
+        'id': u.id,
+        'nom': u.nom,
+        'prenom': u.prenom,
+        'username': u.username,
+        'type': u.type,
+        'is_active': u.is_active
+    } for u in users]), 200

--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -3,6 +3,7 @@ import unicodedata
 from datetime import datetime, timedelta, timezone
 from flask import request, jsonify
 from flask_login import current_user, login_required
+from sqlalchemy.exc import IntegrityError
 from . import admin_bp
 from ..models import db, Employe, Log, User
 from ..decorators import role_required
@@ -106,6 +107,7 @@ def list_users():
 
 @admin_bp.post('/users')
 @login_required
+@role_required('administrateur', 'employé')
 def create_user():
     data = request.get_json(silent=True)
     if not data:
@@ -124,33 +126,37 @@ def create_user():
     if not _can_create(user_type):
         return jsonify({'error': 'Accès refusé'}), 403
 
-    mail_interne = _generate_email(prenom, nom)
-    username = _generate_username(prenom, nom)
-    token = secrets.token_urlsafe(32)
-    expires = datetime.now(timezone.utc) + timedelta(hours=48)
+    for _ in range(5):
+        mail_interne = _generate_email(prenom, nom)
+        username = _generate_username(prenom, nom)
+        token = secrets.token_urlsafe(32)
+        expires = datetime.now(timezone.utc) + timedelta(hours=48)
 
-    user = User(
-        nom=nom,
-        prenom=prenom,
-        type=user_type,
-        username=username,
-        mail_interne=mail_interne,
-        password='',
-        setup_token=token,
-        setup_token_expires=expires
-    )
-    db.session.add(user)
-    db.session.flush()  # get user.id before commit
+        user = User(
+            nom=nom,
+            prenom=prenom,
+            type=user_type,
+            username=username,
+            mail_interne=mail_interne,
+            password='',
+            setup_token=token,
+            setup_token_expires=expires
+        )
+        db.session.add(user)
+        try:
+            db.session.flush()
+            _log('user_created', target_id=user.id)
+            db.session.commit()
+            return jsonify({
+                'id': user.id,
+                'mail_interne': mail_interne,
+                'username': username,
+                'setup_link': f'/auth/setup-password?token={token}'
+            }), 201
+        except IntegrityError:
+            db.session.rollback()
 
-    _log('user_created', target_id=user.id)
-    db.session.commit()
-
-    return jsonify({
-        'id': user.id,
-        'mail_interne': mail_interne,
-        'username': username,
-        'setup_link': f'/auth/setup-password?token={token}'
-    }), 201
+    return jsonify({'error': 'Impossible de générer un identifiant unique'}), 500
 
 
 @admin_bp.patch('/users/<int:user_id>')

--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -47,7 +47,11 @@ def _generate_email(prenom, nom):
 
 
 def _generate_username(prenom, nom):
-    base = f'{_normalize(prenom)[0]}{_normalize(nom)}'
+    prenom_norm = _normalize(prenom)
+    nom_norm = _normalize(nom)
+    first = prenom_norm[0] if prenom_norm else (nom_norm[0] if nom_norm else 'u')
+    nom_norm = nom_norm or 'ser'
+    base = f'{first}{nom_norm}'
     if not User.query.filter_by(username=base).first():
         return base
     i = 2
@@ -151,12 +155,14 @@ def create_user():
                 'id': user.id,
                 'mail_interne': mail_interne,
                 'username': username,
-                'setup_link': f'/auth/setup-password?token={token}'
+                'setup_token': token
             }), 201
         except IntegrityError:
             db.session.rollback()
             mail_interne = _generate_email(prenom, nom)
             username = _generate_username(prenom, nom)
+            token = secrets.token_urlsafe(32)
+            expires = datetime.now(timezone.utc) + timedelta(hours=48)
 
     return jsonify({'error': 'Impossible de générer un identifiant unique'}), 500
 
@@ -169,7 +175,7 @@ def update_user(user_id):
     if user is None:
         return jsonify({'error': 'Utilisateur introuvable'}), 404
     data = request.get_json(silent=True)
-    if not data:
+    if data is None:
         return jsonify({'error': 'JSON requis'}), 400
 
     changes = []

--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -5,7 +5,7 @@ from flask import request, jsonify
 from flask_login import current_user, login_required
 from sqlalchemy.exc import IntegrityError
 from . import admin_bp
-from ..models import db, Employe, Log, User
+from ..models import db, Direction, Log, User
 from ..decorators import role_required
 
 
@@ -62,13 +62,15 @@ def _generate_username(prenom, nom):
         i += 1
 
 
+def _is_direction():
+    return Direction.query.filter_by(id_user=current_user.id).first() is not None
+
+
 def _can_create(requested_type):
     if current_user.type == 'administrateur':
         return True
-    if current_user.type == 'employé':
-        emp = Employe.query.filter_by(id_user=current_user.id).first()
-        if emp and emp.role == 'direction':
-            return requested_type in DIRECTION_TYPES
+    if current_user.type == 'employé' and _is_direction():
+        return requested_type in DIRECTION_TYPES
     return False
 
 
@@ -82,8 +84,7 @@ def list_users():
     query = User.query
 
     if current_user.type == 'employé':
-        emp = Employe.query.filter_by(id_user=current_user.id).first()
-        if not emp or emp.role != 'direction':
+        if not _is_direction():
             return jsonify({'error': 'Accès refusé'}), 403
         query = query.filter(User.type.in_(DIRECTION_TYPES))
 
@@ -114,7 +115,7 @@ def list_users():
 @role_required('administrateur', 'employé')
 def create_user():
     data = request.get_json(silent=True)
-    if not data:
+    if data is None:
         return jsonify({'error': 'JSON requis'}), 400
 
     nom = (data.get('nom') or '').strip()
@@ -169,11 +170,15 @@ def create_user():
 
 @admin_bp.patch('/users/<int:user_id>')
 @login_required
-@role_required('administrateur')
+@role_required('administrateur', 'employé')
 def update_user(user_id):
     user = db.session.get(User, user_id)
     if user is None:
         return jsonify({'error': 'Utilisateur introuvable'}), 404
+
+    if current_user.type == 'employé':
+        if not _is_direction() or user.type not in DIRECTION_TYPES:
+            return jsonify({'error': 'Accès refusé'}), 403
     data = request.get_json(silent=True)
     if data is None:
         return jsonify({'error': 'JSON requis'}), 400
@@ -224,11 +229,15 @@ def update_user(user_id):
 
 @admin_bp.delete('/users/<int:user_id>')
 @login_required
-@role_required('administrateur')
+@role_required('administrateur', 'employé')
 def delete_user(user_id):
     user = db.session.get(User, user_id)
     if user is None:
         return jsonify({'error': 'Utilisateur introuvable'}), 404
+
+    if current_user.type == 'employé':
+        if not _is_direction() or user.type not in DIRECTION_TYPES:
+            return jsonify({'error': 'Accès refusé'}), 403
 
     if user.id == current_user.id:
         return jsonify({'error': 'Impossible de supprimer son propre compte'}), 403

--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -126,12 +126,12 @@ def create_user():
     if not _can_create(user_type):
         return jsonify({'error': 'Accès refusé'}), 403
 
-    for _ in range(5):
-        mail_interne = _generate_email(prenom, nom)
-        username = _generate_username(prenom, nom)
-        token = secrets.token_urlsafe(32)
-        expires = datetime.now(timezone.utc) + timedelta(hours=48)
+    mail_interne = _generate_email(prenom, nom)
+    username = _generate_username(prenom, nom)
+    token = secrets.token_urlsafe(32)
+    expires = datetime.now(timezone.utc) + timedelta(hours=48)
 
+    for _ in range(5):
         user = User(
             nom=nom,
             prenom=prenom,
@@ -155,6 +155,8 @@ def create_user():
             }), 201
         except IntegrityError:
             db.session.rollback()
+            mail_interne = _generate_email(prenom, nom)
+            username = _generate_username(prenom, nom)
 
     return jsonify({'error': 'Impossible de générer un identifiant unique'}), 500
 
@@ -163,7 +165,9 @@ def create_user():
 @login_required
 @role_required('administrateur')
 def update_user(user_id):
-    user = User.query.get_or_404(user_id)
+    user = db.session.get(User, user_id)
+    if user is None:
+        return jsonify({'error': 'Utilisateur introuvable'}), 404
     data = request.get_json(silent=True)
     if not data:
         return jsonify({'error': 'JSON requis'}), 400
@@ -216,7 +220,9 @@ def update_user(user_id):
 @login_required
 @role_required('administrateur')
 def delete_user(user_id):
-    user = User.query.get_or_404(user_id)
+    user = db.session.get(User, user_id)
+    if user is None:
+        return jsonify({'error': 'Utilisateur introuvable'}), 404
 
     if user.id == current_user.id:
         return jsonify({'error': 'Impossible de supprimer son propre compte'}), 403

--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -1,18 +1,73 @@
+import secrets
+import unicodedata
+from datetime import datetime, timedelta, timezone
 from flask import request, jsonify
-from flask_login import login_required
+from flask_login import current_user, login_required
 from . import admin_bp
-from ..models import User
+from ..models import db, Employe, User
 from ..decorators import role_required
+
+ALLOWED_TYPES = {'élève', 'employé', 'parent', 'administrateur'}
+DIRECTION_TYPES = {'élève', 'parent'}
+
+
+def _normalize(s):
+    """Lowercase, remove accents and spaces."""
+    s = unicodedata.normalize('NFD', s)
+    s = ''.join(c for c in s if unicodedata.category(c) != 'Mn')
+    return s.lower().replace(' ', '').replace('-', '')
+
+
+def _generate_email(prenom, nom):
+    base = f'{_normalize(prenom)}.{_normalize(nom)}@guardiaschool.fr'
+    if not User.query.filter_by(mail_interne=base).first():
+        return base
+    i = 2
+    while True:
+        candidate = (
+            f'{_normalize(prenom)}.{_normalize(nom)}{i}@guardiaschool.fr'
+        )
+        if not User.query.filter_by(mail_interne=candidate).first():
+            return candidate
+        i += 1
+
+
+def _generate_username(prenom, nom):
+    base = f'{_normalize(prenom)[0]}{_normalize(nom)}'
+    if not User.query.filter_by(username=base).first():
+        return base
+    i = 2
+    while True:
+        candidate = f'{base}{i}'
+        if not User.query.filter_by(username=candidate).first():
+            return candidate
+        i += 1
+
+
+def _can_create(requested_type):
+    if current_user.type == 'administrateur':
+        return True
+    if current_user.type == 'employé':
+        emp = Employe.query.filter_by(id_user=current_user.id).first()
+        if emp and emp.role == 'direction':
+            return requested_type in DIRECTION_TYPES
+    return False
 
 
 @admin_bp.get('/users')
 @login_required
-@role_required('administrateur')
+@role_required('administrateur', 'employé')
 def list_users():
     type_filter = request.args.get('type', '').strip()
     search = request.args.get('search', '').strip()
 
     query = User.query
+
+    if current_user.type == 'employé':
+        emp = Employe.query.filter_by(id_user=current_user.id).first()
+        if not emp or emp.role != 'direction':
+            return jsonify({'error': 'Accès refusé'}), 403
+        query = query.filter(User.type.in_(DIRECTION_TYPES))
 
     if type_filter:
         query = query.filter(User.type == type_filter)
@@ -34,3 +89,49 @@ def list_users():
         'type': u.type,
         'is_active': u.is_active
     } for u in users]), 200
+
+
+@admin_bp.post('/users')
+@login_required
+def create_user():
+    data = request.get_json(silent=True)
+    if not data:
+        return jsonify({'error': 'JSON requis'}), 400
+
+    nom = (data.get('nom') or '').strip()
+    prenom = (data.get('prenom') or '').strip()
+    user_type = (data.get('type') or '').strip()
+
+    if not nom or not prenom or not user_type:
+        return jsonify({'error': 'nom, prenom et type sont requis'}), 400
+
+    if user_type not in ALLOWED_TYPES:
+        return jsonify({'error': 'Type invalide'}), 400
+
+    if not _can_create(user_type):
+        return jsonify({'error': 'Accès refusé'}), 403
+
+    mail_interne = _generate_email(prenom, nom)
+    username = _generate_username(prenom, nom)
+    token = secrets.token_urlsafe(32)
+    expires = datetime.now(timezone.utc) + timedelta(hours=48)
+
+    user = User(
+        nom=nom,
+        prenom=prenom,
+        type=user_type,
+        username=username,
+        mail_interne=mail_interne,
+        password='',
+        setup_token=token,
+        setup_token_expires=expires
+    )
+    db.session.add(user)
+    db.session.commit()
+
+    return jsonify({
+        'id': user.id,
+        'mail_interne': mail_interne,
+        'username': username,
+        'setup_link': f'/auth/setup-password?token={token}'
+    }), 201

--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -4,8 +4,21 @@ from datetime import datetime, timedelta, timezone
 from flask import request, jsonify
 from flask_login import current_user, login_required
 from . import admin_bp
-from ..models import db, Employe, User
+from ..models import db, Employe, Log, User
 from ..decorators import role_required
+
+
+def _log(action, target_id=None):
+    db.session.add(Log(
+        user_id=current_user.id,
+        action=action,
+        target_type='user',
+        target_id=target_id,
+        ip_address=request.remote_addr,
+        user_agent=(request.user_agent.string or '')[:255],
+        created_at=datetime.now(timezone.utc)
+    ))
+
 
 ALLOWED_TYPES = {'élève', 'employé', 'parent', 'administrateur'}
 DIRECTION_TYPES = {'élève', 'parent'}
@@ -127,6 +140,9 @@ def create_user():
         setup_token_expires=expires
     )
     db.session.add(user)
+    db.session.flush()  # get user.id before commit
+
+    _log('user_created', target_id=user.id)
     db.session.commit()
 
     return jsonify({
@@ -135,3 +151,72 @@ def create_user():
         'username': username,
         'setup_link': f'/auth/setup-password?token={token}'
     }), 201
+
+
+@admin_bp.patch('/users/<int:user_id>')
+@login_required
+@role_required('administrateur')
+def update_user(user_id):
+    user = User.query.get_or_404(user_id)
+    data = request.get_json(silent=True)
+    if not data:
+        return jsonify({'error': 'JSON requis'}), 400
+
+    changes = []
+
+    if 'nom' in data:
+        nom = (data['nom'] or '').strip()
+        if not nom:
+            return jsonify({'error': 'nom ne peut pas être vide'}), 400
+        user.nom = nom
+        changes.append('nom')
+
+    if 'prenom' in data:
+        prenom = (data['prenom'] or '').strip()
+        if not prenom:
+            return jsonify({'error': 'prenom ne peut pas être vide'}), 400
+        user.prenom = prenom
+        changes.append('prenom')
+
+    if 'type' in data:
+        user_type = (data['type'] or '').strip()
+        if user_type not in ALLOWED_TYPES:
+            return jsonify({'error': 'Type invalide'}), 400
+        user.type = user_type
+        changes.append('type')
+
+    if 'is_active' in data:
+        if not isinstance(data['is_active'], bool):
+            return jsonify({'error': 'is_active doit être un booléen'}), 400
+        user.is_active = data['is_active']
+        changes.append('is_active')
+
+    if not changes:
+        return jsonify({'error': 'Aucun champ modifiable fourni'}), 400
+
+    _log(f'user_updated:{",".join(changes)}', target_id=user.id)
+    db.session.commit()
+
+    return jsonify({
+        'id': user.id,
+        'nom': user.nom,
+        'prenom': user.prenom,
+        'type': user.type,
+        'is_active': user.is_active
+    }), 200
+
+
+@admin_bp.delete('/users/<int:user_id>')
+@login_required
+@role_required('administrateur')
+def delete_user(user_id):
+    user = User.query.get_or_404(user_id)
+
+    if user.id == current_user.id:
+        return jsonify({'error': 'Impossible de supprimer son propre compte'}), 403
+
+    _log('user_deleted', target_id=user.id)
+    db.session.delete(user)
+    db.session.commit()
+
+    return jsonify({'message': 'Compte supprimé'}), 200

--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -34,7 +34,10 @@ def login():
 
     user = User.query.filter_by(mail_interne=email).first()
 
-    if not user or not bcrypt.check_password_hash(user.password, password):
+    password_ok = (
+        user and user.password and bcrypt.check_password_hash(user.password, password)
+    )
+    if not password_ok:
         _log('login_failure')
         db.session.commit()
         return jsonify({'error': 'Identifiants invalides'}), 401
@@ -147,9 +150,10 @@ def contact_direction():
 
 
 @auth_bp.post('/setup-password')
+@limiter.limit('5 per minute')
 def setup_password():
     data = request.get_json(silent=True)
-    if not data:
+    if data is None:
         return jsonify({'error': 'JSON requis'}), 400
 
     token = (data.get('token') or '').strip()

--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -27,13 +27,13 @@ def login():
     if not data:
         return jsonify({'error': 'JSON requis'}), 400
 
-    username = (data.get('username') or '').strip()
+    email = (data.get('email') or '').strip().lower()
     password = data.get('password') or ''
 
-    if not username or not password:
+    if not email or not password:
         return jsonify({'error': 'Identifiants requis'}), 400
 
-    user = User.query.filter_by(username=username).first()
+    user = User.query.filter_by(mail_interne=email).first()
 
     if not user or not bcrypt.check_password_hash(user.password, password):
         _log('login_failure')

--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -4,8 +4,7 @@ from flask import request, jsonify, session
 from flask_login import current_user, login_required, login_user, logout_user
 from . import auth_bp
 from ..models import db, Direction, Information, Log, Mail, User
-from .. import bcrypt
-from .. import limiter
+from .. import bcrypt, limiter
 
 
 def _log(action, user_id=None, target_type=None, target_id=None):
@@ -145,3 +144,41 @@ def contact_direction():
     _log('contact_direction', user_id=current_user.id, target_type='direction')
     db.session.commit()
     return jsonify({'message': 'Demande envoyée à la direction'}), 201
+
+
+@auth_bp.post('/setup-password')
+def setup_password():
+    data = request.get_json(silent=True)
+    if not data:
+        return jsonify({'error': 'JSON requis'}), 400
+
+    token = (data.get('token') or '').strip()
+    password = data.get('password') or ''
+
+    if not token or not password:
+        return jsonify({'error': 'token et password sont requis'}), 400
+
+    if len(password) < 8:
+        return jsonify(
+            {'error': 'Le mot de passe doit contenir au moins 8 caractères'}
+        ), 400
+
+    user = User.query.filter_by(setup_token=token).first()
+
+    if not user:
+        return jsonify({'error': 'Lien invalide'}), 400
+
+    now = datetime.now(timezone.utc)
+    expires = user.setup_token_expires
+    if expires.tzinfo is None:
+        expires = expires.replace(tzinfo=timezone.utc)
+
+    if now > expires:
+        return jsonify({'error': 'Lien expiré'}), 400
+
+    user.password = bcrypt.generate_password_hash(password).decode('utf-8')
+    user.setup_token = None
+    user.setup_token_expires = None
+    _log('password_setup', user_id=user.id)
+    db.session.commit()
+    return jsonify({'message': 'Mot de passe configuré'}), 200

--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -165,7 +165,7 @@ def setup_password():
 
     user = User.query.filter_by(setup_token=token).first()
 
-    if not user:
+    if not user or not user.setup_token_expires:
         return jsonify({'error': 'Lien invalide'}), 400
 
     now = datetime.now(timezone.utc)

--- a/app/decorators.py
+++ b/app/decorators.py
@@ -1,0 +1,14 @@
+from functools import wraps
+from flask import jsonify
+from flask_login import current_user
+
+
+def role_required(*roles):
+    def decorator(f):
+        @wraps(f)
+        def decorated_function(*args, **kwargs):
+            if current_user.type not in roles:
+                return jsonify({'error': 'Accès refusé'}), 403
+            return f(*args, **kwargs)
+        return decorated_function
+    return decorator

--- a/app/decorators.py
+++ b/app/decorators.py
@@ -7,7 +7,9 @@ def role_required(*roles):
     def decorator(f):
         @wraps(f)
         def decorated_function(*args, **kwargs):
-            if current_user.type not in roles:
+            if not current_user.is_authenticated:
+                return jsonify({'error': 'Authentification requise'}), 401
+            if getattr(current_user, 'type', None) not in roles:
                 return jsonify({'error': 'Accès refusé'}), 403
             return f(*args, **kwargs)
         return decorated_function

--- a/app/models.py
+++ b/app/models.py
@@ -26,6 +26,8 @@ class User(UserMixin, db.Model):
     password = db.Column(db.String(255), nullable=False)
     mail_interne = db.Column(db.String(150), unique=True)
     is_active = db.Column(db.Boolean, default=True, nullable=False)
+    setup_token = db.Column(db.String(100), unique=True, nullable=True)
+    setup_token_expires = db.Column(db.DateTime, nullable=True)
 
 
 class Information(db.Model):

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -46,7 +46,9 @@ CREATE TABLE User (
     Username     VARCHAR(100) NOT NULL UNIQUE,
     Password     VARCHAR(255) NOT NULL,
     Mail_Interne VARCHAR(150) UNIQUE,
-    Is_Active    BOOLEAN NOT NULL DEFAULT TRUE
+    Is_Active           BOOLEAN NOT NULL DEFAULT TRUE,
+    Setup_Token         VARCHAR(100) UNIQUE,
+    Setup_Token_Expires DATETIME
 );
 
 -- ============================================================

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+filterwarnings =
+    ignore::UserWarning:flask_limiter

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,7 @@ def user(app):
             nom='Test',
             prenom='User',
             username='testuser',
+            mail_interne='user.test@guardiaschool.fr',
             password=bcrypt.generate_password_hash('password123').decode('utf-8')
         )
         db.session.add(u)
@@ -41,6 +42,7 @@ def direction(app):
             nom='Direction',
             prenom='Admin',
             username='direction',
+            mail_interne='admin.direction@guardiaschool.fr',
             password=bcrypt.generate_password_hash('dirpassword').decode('utf-8')
         )
         db.session.add(dir_user)

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,7 +1,23 @@
 import pytest
 from datetime import datetime, timedelta, timezone
 from app import bcrypt
-from app.models import Employe, User, db
+from app.models import Direction, User, db
+
+
+@pytest.fixture
+def direction_user(app):
+    with app.app_context():
+        u = User(
+            type='employé', nom='Dir', prenom='Chef',
+            username='cdirecteur',
+            mail_interne='chef.dir@guardiaschool.fr',
+            password=bcrypt.generate_password_hash('dirpass').decode('utf-8')
+        )
+        db.session.add(u)
+        db.session.flush()
+        db.session.add(Direction(id_user=u.id))
+        db.session.commit()
+        yield u
 
 
 @pytest.fixture
@@ -143,19 +159,8 @@ def test_create_user_invalid_type(client, admin):
     assert response.status_code == 400
 
 
-def test_create_user_direction_forbidden_type(client, app):
+def test_create_user_direction_forbidden_type(client, direction_user):
     # direction ne peut pas créer un admin => 403
-    with app.app_context():
-        dir_user = User(
-            type='employé', nom='Dir', prenom='Chef',
-            username='cdirecteur',
-            mail_interne='chef.dir@guardiaschool.fr',
-            password=bcrypt.generate_password_hash('dirpass').decode('utf-8')
-        )
-        db.session.add(dir_user)
-        db.session.flush()
-        db.session.add(Employe(id_user=dir_user.id, role='direction'))
-        db.session.commit()
     client.post('/auth/login', json={
         'email': 'chef.dir@guardiaschool.fr', 'password': 'dirpass'
     })
@@ -364,3 +369,41 @@ def test_delete_user_unauthenticated(client, eleve):
     # non connecté => 401
     response = client.delete(f'/admin/users/{eleve.id}')
     assert response.status_code == 401
+
+
+# --- RBAC direction sur PATCH/DELETE ---
+
+def test_direction_can_update_eleve(client, direction_user, eleve):
+    # direction peut modifier un élève => 200
+    client.post('/auth/login', json={
+        'email': 'chef.dir@guardiaschool.fr', 'password': 'dirpass'
+    })
+    response = client.patch(f'/admin/users/{eleve.id}', json={'is_active': False})
+    assert response.status_code == 200
+
+
+def test_direction_cannot_update_admin(client, direction_user, admin):
+    # direction ne peut pas modifier un admin => 403
+    client.post('/auth/login', json={
+        'email': 'chef.dir@guardiaschool.fr', 'password': 'dirpass'
+    })
+    response = client.patch(f'/admin/users/{admin.id}', json={'nom': 'Hack'})
+    assert response.status_code == 403
+
+
+def test_direction_can_delete_eleve(client, direction_user, eleve):
+    # direction peut supprimer un élève => 200
+    client.post('/auth/login', json={
+        'email': 'chef.dir@guardiaschool.fr', 'password': 'dirpass'
+    })
+    response = client.delete(f'/admin/users/{eleve.id}')
+    assert response.status_code == 200
+
+
+def test_direction_cannot_delete_admin(client, direction_user, admin):
+    # direction ne peut pas supprimer un admin => 403
+    client.post('/auth/login', json={
+        'email': 'chef.dir@guardiaschool.fr', 'password': 'dirpass'
+    })
+    response = client.delete(f'/admin/users/{admin.id}')
+    assert response.status_code == 403

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -253,3 +253,114 @@ def test_setup_password_too_short(client, app):
         'password': 'court'
     })
     assert response.status_code == 400
+
+
+# --- PATCH /admin/users/<id> ---
+
+def test_update_user_success(client, admin, eleve):
+    # admin modifie nom et is_active => 200
+    client.post('/auth/login', json={
+        'email': 'test.admin@guardiaschool.fr', 'password': 'adminpass'
+    })
+    response = client.patch(f'/admin/users/{eleve.id}', json={
+        'nom': 'Durand', 'is_active': False
+    })
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data['nom'] == 'Durand'
+    assert data['is_active'] is False
+
+
+def test_update_user_invalid_type(client, admin, eleve):
+    # type invalide => 400
+    client.post('/auth/login', json={
+        'email': 'test.admin@guardiaschool.fr', 'password': 'adminpass'
+    })
+    response = client.patch(f'/admin/users/{eleve.id}', json={'type': 'inconnu'})
+    assert response.status_code == 400
+
+
+def test_update_user_empty_nom(client, admin, eleve):
+    # nom vide => 400
+    client.post('/auth/login', json={
+        'email': 'test.admin@guardiaschool.fr', 'password': 'adminpass'
+    })
+    response = client.patch(f'/admin/users/{eleve.id}', json={'nom': '  '})
+    assert response.status_code == 400
+
+
+def test_update_user_no_fields(client, admin, eleve):
+    # aucun champ modifiable => 400
+    client.post('/auth/login', json={
+        'email': 'test.admin@guardiaschool.fr', 'password': 'adminpass'
+    })
+    response = client.patch(f'/admin/users/{eleve.id}', json={})
+    assert response.status_code == 400
+
+
+def test_update_user_not_found(client, admin):
+    # user inexistant => 404
+    client.post('/auth/login', json={
+        'email': 'test.admin@guardiaschool.fr', 'password': 'adminpass'
+    })
+    response = client.patch('/admin/users/9999', json={'nom': 'Test'})
+    assert response.status_code == 404
+
+
+def test_update_user_forbidden(client, admin, eleve):
+    # élève => 403
+    client.post('/auth/login', json={
+        'email': 'jean.dupont@guardiaschool.fr', 'password': 'password'
+    })
+    response = client.patch(f'/admin/users/{eleve.id}', json={'nom': 'Hack'})
+    assert response.status_code == 403
+
+
+def test_update_user_unauthenticated(client, eleve):
+    # non connecté => 401
+    response = client.patch(f'/admin/users/{eleve.id}', json={'nom': 'Test'})
+    assert response.status_code == 401
+
+
+# --- DELETE /admin/users/<id> ---
+
+def test_delete_user_success(client, admin, eleve):
+    # admin supprime un élève => 200
+    client.post('/auth/login', json={
+        'email': 'test.admin@guardiaschool.fr', 'password': 'adminpass'
+    })
+    response = client.delete(f'/admin/users/{eleve.id}')
+    assert response.status_code == 200
+
+
+def test_delete_user_self(client, admin):
+    # admin ne peut pas se supprimer lui-même => 403
+    client.post('/auth/login', json={
+        'email': 'test.admin@guardiaschool.fr', 'password': 'adminpass'
+    })
+    response = client.delete(f'/admin/users/{admin.id}')
+    assert response.status_code == 403
+
+
+def test_delete_user_not_found(client, admin):
+    # user inexistant => 404
+    client.post('/auth/login', json={
+        'email': 'test.admin@guardiaschool.fr', 'password': 'adminpass'
+    })
+    response = client.delete('/admin/users/9999')
+    assert response.status_code == 404
+
+
+def test_delete_user_forbidden(client, admin, eleve):
+    # élève => 403
+    client.post('/auth/login', json={
+        'email': 'jean.dupont@guardiaschool.fr', 'password': 'password'
+    })
+    response = client.delete(f'/admin/users/{eleve.id}')
+    assert response.status_code == 403
+
+
+def test_delete_user_unauthenticated(client, eleve):
+    # non connecté => 401
+    response = client.delete(f'/admin/users/{eleve.id}')
+    assert response.status_code == 401

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,0 +1,92 @@
+import pytest
+from app import bcrypt
+from app.models import User, db
+
+
+@pytest.fixture
+def admin(app):
+    with app.app_context():
+        u = User(
+            type='administrateur', nom='Admin', prenom='Test',
+            username='admin',
+            password=bcrypt.generate_password_hash('adminpass').decode('utf-8')
+        )
+        db.session.add(u)
+        db.session.commit()
+        yield u
+
+
+@pytest.fixture
+def eleve(app):
+    with app.app_context():
+        u = User(
+            type='élève', nom='Dupont', prenom='Jean',
+            username='jdupont',
+            password=bcrypt.generate_password_hash('password').decode('utf-8')
+        )
+        db.session.add(u)
+        db.session.commit()
+        yield u
+
+
+def test_list_users_success(client, admin, eleve):
+    # admin connecté => 200 + liste des users
+    client.post('/auth/login', json={
+        'username': 'admin', 'password': 'adminpass'
+    })
+    response = client.get('/admin/users')
+    assert response.status_code == 200
+    data = response.get_json()
+    assert isinstance(data, list)
+    assert len(data) == 2
+
+
+def test_list_users_filter_type(client, admin, eleve):
+    # filtre par type => retourne uniquement les élèves
+    client.post('/auth/login', json={
+        'username': 'admin', 'password': 'adminpass'
+    })
+    response = client.get('/admin/users?type=élève')
+    assert response.status_code == 200
+    data = response.get_json()
+    assert all(u['type'] == 'élève' for u in data)
+    assert len(data) == 1
+
+
+def test_list_users_search(client, admin, eleve):
+    # recherche par nom => retourne uniquement Dupont
+    client.post('/auth/login', json={
+        'username': 'admin', 'password': 'adminpass'
+    })
+    response = client.get('/admin/users?search=dupont')
+    assert response.status_code == 200
+    data = response.get_json()
+    assert len(data) == 1
+    assert data[0]['nom'] == 'Dupont'
+
+
+def test_list_users_search_username(client, admin, eleve):
+    # recherche par username
+    client.post('/auth/login', json={
+        'username': 'admin', 'password': 'adminpass'
+    })
+    response = client.get('/admin/users?search=jdupont')
+    assert response.status_code == 200
+    data = response.get_json()
+    assert len(data) == 1
+    assert data[0]['username'] == 'jdupont'
+
+
+def test_list_users_forbidden_eleve(client, admin, eleve):
+    # élève => 403
+    client.post('/auth/login', json={
+        'username': 'jdupont', 'password': 'password'
+    })
+    response = client.get('/admin/users')
+    assert response.status_code == 403
+
+
+def test_list_users_unauthenticated(client):
+    # non connecté => 401
+    response = client.get('/admin/users')
+    assert response.status_code == 401

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -107,7 +107,7 @@ def test_create_user_success(client, admin):
     })
     assert response.status_code == 201
     data = response.get_json()
-    assert 'setup_link' in data
+    assert 'setup_token' in data
     assert data['mail_interne'] == 'alice.martin@guardiaschool.fr'
 
 

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,6 +1,7 @@
 import pytest
+from datetime import datetime, timedelta, timezone
 from app import bcrypt
-from app.models import User, db
+from app.models import Employe, User, db
 
 
 @pytest.fixture
@@ -92,3 +93,163 @@ def test_list_users_unauthenticated(client):
     # non connecté => 401
     response = client.get('/admin/users')
     assert response.status_code == 401
+
+
+# --- POST /admin/users ---
+
+def test_create_user_success(client, admin):
+    # admin crée un élève => 201 + setup_link
+    client.post('/auth/login', json={
+        'email': 'test.admin@guardiaschool.fr', 'password': 'adminpass'
+    })
+    response = client.post('/admin/users', json={
+        'nom': 'Martin', 'prenom': 'Alice', 'type': 'élève'
+    })
+    assert response.status_code == 201
+    data = response.get_json()
+    assert 'setup_link' in data
+    assert data['mail_interne'] == 'alice.martin@guardiaschool.fr'
+
+
+def test_create_user_email_dedup(client, admin, eleve):
+    # jean.dupont existe déjà => jean.dupont2
+    client.post('/auth/login', json={
+        'email': 'test.admin@guardiaschool.fr', 'password': 'adminpass'
+    })
+    response = client.post('/admin/users', json={
+        'nom': 'Dupont', 'prenom': 'Jean', 'type': 'élève'
+    })
+    assert response.status_code == 201
+    assert response.get_json()['mail_interne'] == 'jean.dupont2@guardiaschool.fr'
+
+
+def test_create_user_missing_fields(client, admin):
+    # champs manquants => 400
+    client.post('/auth/login', json={
+        'email': 'test.admin@guardiaschool.fr', 'password': 'adminpass'
+    })
+    response = client.post('/admin/users', json={'nom': 'Martin'})
+    assert response.status_code == 400
+
+
+def test_create_user_invalid_type(client, admin):
+    # type inconnu => 400
+    client.post('/auth/login', json={
+        'email': 'test.admin@guardiaschool.fr', 'password': 'adminpass'
+    })
+    response = client.post('/admin/users', json={
+        'nom': 'Martin', 'prenom': 'Alice', 'type': 'inconnu'
+    })
+    assert response.status_code == 400
+
+
+def test_create_user_direction_forbidden_type(client, app):
+    # direction ne peut pas créer un admin => 403
+    with app.app_context():
+        dir_user = User(
+            type='employé', nom='Dir', prenom='Chef',
+            username='cdirecteur',
+            mail_interne='chef.dir@guardiaschool.fr',
+            password=bcrypt.generate_password_hash('dirpass').decode('utf-8')
+        )
+        db.session.add(dir_user)
+        db.session.flush()
+        db.session.add(Employe(id_user=dir_user.id, role='direction'))
+        db.session.commit()
+    client.post('/auth/login', json={
+        'email': 'chef.dir@guardiaschool.fr', 'password': 'dirpass'
+    })
+    response = client.post('/admin/users', json={
+        'nom': 'Martin', 'prenom': 'Alice', 'type': 'administrateur'
+    })
+    assert response.status_code == 403
+
+
+def test_create_user_forbidden_eleve(client, admin, eleve):
+    # élève => 403
+    client.post('/auth/login', json={
+        'email': 'jean.dupont@guardiaschool.fr', 'password': 'password'
+    })
+    response = client.post('/admin/users', json={
+        'nom': 'Martin', 'prenom': 'Alice', 'type': 'élève'
+    })
+    assert response.status_code == 403
+
+
+def test_create_user_unauthenticated(client):
+    # non connecté => 401
+    response = client.post('/admin/users', json={
+        'nom': 'Martin', 'prenom': 'Alice', 'type': 'élève'
+    })
+    assert response.status_code == 401
+
+
+# --- POST /auth/setup-password ---
+
+def test_setup_password_success(client, app):
+    # token valide => 200, password configuré
+    with app.app_context():
+        u = User(
+            type='élève', nom='New', prenom='User',
+            username='nuser',
+            mail_interne='user.new@guardiaschool.fr',
+            password='',
+            setup_token='validtoken123',
+            setup_token_expires=datetime.now(timezone.utc) + timedelta(hours=48)
+        )
+        db.session.add(u)
+        db.session.commit()
+    response = client.post('/auth/setup-password', json={
+        'token': 'validtoken123',
+        'password': 'MonMotDePasse1!'
+    })
+    assert response.status_code == 200
+
+
+def test_setup_password_invalid_token(client):
+    # token inexistant => 400
+    response = client.post('/auth/setup-password', json={
+        'token': 'tokeninexistant',
+        'password': 'MonMotDePasse1!'
+    })
+    assert response.status_code == 400
+
+
+def test_setup_password_expired_token(client, app):
+    # token expiré => 400
+    with app.app_context():
+        u = User(
+            type='élève', nom='Old', prenom='User',
+            username='ouser',
+            mail_interne='user.old@guardiaschool.fr',
+            password='',
+            setup_token='expiredtoken123',
+            setup_token_expires=datetime.now(timezone.utc) - timedelta(hours=1)
+        )
+        db.session.add(u)
+        db.session.commit()
+    response = client.post('/auth/setup-password', json={
+        'token': 'expiredtoken123',
+        'password': 'MonMotDePasse1!'
+    })
+    assert response.status_code == 400
+
+
+def test_setup_password_too_short(client, app):
+    # mot de passe trop court => 400
+    with app.app_context():
+        u = User(
+            type='élève', nom='Short', prenom='User',
+            username='suser',
+            mail_interne='user.short@guardiaschool.fr',
+            password='',
+            setup_token='shortpasstoken',
+            setup_token_expires=datetime.now(timezone.utc) + timedelta(hours=48)
+        )
+        db.session.add(u)
+        db.session.commit()
+    response = client.post('/auth/setup-password', json={
+        'token': 'shortpasstoken',
+        'password': 'court'
+    })
+    assert response.status_code == 400

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -9,6 +9,7 @@ def admin(app):
         u = User(
             type='administrateur', nom='Admin', prenom='Test',
             username='admin',
+            mail_interne='test.admin@guardiaschool.fr',
             password=bcrypt.generate_password_hash('adminpass').decode('utf-8')
         )
         db.session.add(u)
@@ -22,6 +23,7 @@ def eleve(app):
         u = User(
             type='élève', nom='Dupont', prenom='Jean',
             username='jdupont',
+            mail_interne='jean.dupont@guardiaschool.fr',
             password=bcrypt.generate_password_hash('password').decode('utf-8')
         )
         db.session.add(u)
@@ -32,7 +34,7 @@ def eleve(app):
 def test_list_users_success(client, admin, eleve):
     # admin connecté => 200 + liste des users
     client.post('/auth/login', json={
-        'username': 'admin', 'password': 'adminpass'
+        'email': 'test.admin@guardiaschool.fr', 'password': 'adminpass'
     })
     response = client.get('/admin/users')
     assert response.status_code == 200
@@ -44,7 +46,7 @@ def test_list_users_success(client, admin, eleve):
 def test_list_users_filter_type(client, admin, eleve):
     # filtre par type => retourne uniquement les élèves
     client.post('/auth/login', json={
-        'username': 'admin', 'password': 'adminpass'
+        'email': 'test.admin@guardiaschool.fr', 'password': 'adminpass'
     })
     response = client.get('/admin/users?type=élève')
     assert response.status_code == 200
@@ -56,7 +58,7 @@ def test_list_users_filter_type(client, admin, eleve):
 def test_list_users_search(client, admin, eleve):
     # recherche par nom => retourne uniquement Dupont
     client.post('/auth/login', json={
-        'username': 'admin', 'password': 'adminpass'
+        'email': 'test.admin@guardiaschool.fr', 'password': 'adminpass'
     })
     response = client.get('/admin/users?search=dupont')
     assert response.status_code == 200
@@ -68,7 +70,7 @@ def test_list_users_search(client, admin, eleve):
 def test_list_users_search_username(client, admin, eleve):
     # recherche par username
     client.post('/auth/login', json={
-        'username': 'admin', 'password': 'adminpass'
+        'email': 'test.admin@guardiaschool.fr', 'password': 'adminpass'
     })
     response = client.get('/admin/users?search=jdupont')
     assert response.status_code == 200
@@ -80,7 +82,7 @@ def test_list_users_search_username(client, admin, eleve):
 def test_list_users_forbidden_eleve(client, admin, eleve):
     # élève => 403
     client.post('/auth/login', json={
-        'username': 'jdupont', 'password': 'password'
+        'email': 'jean.dupont@guardiaschool.fr', 'password': 'password'
     })
     response = client.get('/admin/users')
     assert response.status_code == 403

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,7 +1,7 @@
 def test_login_success(client, user):
-    # POST /auth/login avec bon username/password => 200 + role
+    # POST /auth/login avec bon email/password => 200 + role
     response = client.post('/auth/login', json={
-        'username': 'testuser',
+        'email': 'user.test@guardiaschool.fr',
         'password': 'password123'
     })
     assert response.status_code == 200
@@ -11,16 +11,16 @@ def test_login_success(client, user):
 def test_login_wrong_password(client, user):
     # POST /auth/login avec mauvais password => 401
     response = client.post('/auth/login', json={
-        'username': 'testuser',
+        'email': 'user.test@guardiaschool.fr',
         'password': 'wrongpassword'
     })
     assert response.status_code == 401
 
 
 def test_login_unknown_user(client):
-    # POST /auth/login avec username inexistant => 401
+    # POST /auth/login avec email inexistant => 401
     response = client.post('/auth/login', json={
-        'username': 'unknownuser',
+        'email': 'inconnu@guardiaschool.fr',
         'password': 'password123'
     })
     assert response.status_code == 401
@@ -34,13 +34,14 @@ def test_login_inactive_user(client, app):
         u = User(
             type='élève', nom='Inactif', prenom='User',
             username='inactif',
+            mail_interne='user.inactif@guardiaschool.fr',
             password=bcrypt.generate_password_hash('password123').decode('utf-8'),
             is_active=False
         )
         db.session.add(u)
         db.session.commit()
     response = client.post('/auth/login', json={
-        'username': 'inactif',
+        'email': 'user.inactif@guardiaschool.fr',
         'password': 'password123'
     })
     assert response.status_code == 403
@@ -56,14 +57,14 @@ def test_login_no_json(client):
 
 def test_login_empty_fields(client):
     # champs vides => 400
-    response = client.post('/auth/login', json={'username': '', 'password': ''})
+    response = client.post('/auth/login', json={'email': '', 'password': ''})
     assert response.status_code == 400
 
 
 def test_logout(client, user):
     # login d'abord, puis POST /auth/logout => 200
     client.post('/auth/login', json={
-        'username': 'testuser',
+        'email': 'user.test@guardiaschool.fr',
         'password': 'password123'
     })
     response = client.post('/auth/logout')
@@ -79,7 +80,7 @@ def test_logout_unauthenticated(client):
 def test_change_password_success(client, user):
     # login, puis changement de mot de passe valide => 200
     client.post('/auth/login', json={
-        'username': 'testuser',
+        'email': 'user.test@guardiaschool.fr',
         'password': 'password123'
     })
     response = client.patch('/auth/profile/password', json={
@@ -92,7 +93,7 @@ def test_change_password_success(client, user):
 def test_change_password_wrong_current(client, user):
     # mauvais mot de passe actuel => 400
     client.post('/auth/login', json={
-        'username': 'testuser',
+        'email': 'user.test@guardiaschool.fr',
         'password': 'password123'
     })
     response = client.patch('/auth/profile/password', json={
@@ -105,7 +106,7 @@ def test_change_password_wrong_current(client, user):
 def test_change_password_too_short(client, user):
     # nouveau mot de passe trop court => 400
     client.post('/auth/login', json={
-        'username': 'testuser',
+        'email': 'user.test@guardiaschool.fr',
         'password': 'password123'
     })
     response = client.patch('/auth/profile/password', json={
@@ -127,7 +128,7 @@ def test_change_password_unauthenticated(client):
 def test_change_phone_success(client, user):
     # login, puis numéro valide => 200
     client.post('/auth/login', json={
-        'username': 'testuser',
+        'email': 'user.test@guardiaschool.fr',
         'password': 'password123'
     })
     response = client.patch('/auth/profile/phone', json={'numero': '0612345678'})
@@ -137,7 +138,7 @@ def test_change_phone_success(client, user):
 def test_change_phone_invalid(client, user):
     # numéro invalide => 400
     client.post('/auth/login', json={
-        'username': 'testuser',
+        'email': 'user.test@guardiaschool.fr',
         'password': 'password123'
     })
     response = client.patch('/auth/profile/phone', json={'numero': '123'})
@@ -153,7 +154,7 @@ def test_change_phone_unauthenticated(client):
 def test_contact_direction_success(client, user, direction):
     # login, champ valide, direction existe => 201
     client.post('/auth/login', json={
-        'username': 'testuser',
+        'email': 'user.test@guardiaschool.fr',
         'password': 'password123'
     })
     response = client.post('/auth/profile/contact-direction', json={'champ': 'nom'})
@@ -163,7 +164,7 @@ def test_contact_direction_success(client, user, direction):
 def test_contact_direction_invalid_champ(client, user, direction):
     # champ non autorisé => 400
     client.post('/auth/login', json={
-        'username': 'testuser',
+        'email': 'user.test@guardiaschool.fr',
         'password': 'password123'
     })
     response = client.post(
@@ -175,7 +176,7 @@ def test_contact_direction_invalid_champ(client, user, direction):
 def test_contact_direction_no_direction(client, user):
     # pas de direction en base => 404
     client.post('/auth/login', json={
-        'username': 'testuser',
+        'email': 'user.test@guardiaschool.fr',
         'password': 'password123'
     })
     response = client.post('/auth/profile/contact-direction', json={'champ': 'nom'})


### PR DESCRIPTION
## Summary

- `GET /admin/users` — liste avec filtres par type et recherche (nom, username)
- `POST /admin/users` — création avec username/email auto-générés et token d'invitation 48h
- `POST /auth/setup-password` — activation du compte via token
- `PATCH /admin/users/<id>` — modification nom, prénom, type, is_active
- `DELETE /admin/users/<id>` — suppression avec blocage auto-suppression

RBAC : admin = accès total, direction = élèves/parents uniquement.
Toutes les actions sensibles sont loggées en base.

Closes #39
Closes #40
Closes #41
Closes #42

## Test plan

- [x] 49 tests passent (`pytest tests/`)
- [x] Flake8 sans erreur
- [ ] Tester `POST /admin/users` en tant qu'élève → 403
- [ ] Tester `DELETE /admin/users/<id>` sur son propre compte → 403
- [ ] Tester `POST /auth/setup-password` avec token expiré → 400