### PR TITLE
feat: emploi du temps - CRUD cours avec RBAC

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,54 @@
+name: Integration Tests (MySQL)
+
+on:
+  workflow_dispatch:
+
+jobs:
+  integration:
+    name: Tests contre MySQL réel
+    runs-on: ubuntu-latest
+
+    services:
+      db:
+        image: mysql:8
+        env:
+          MYSQL_DATABASE: school_db
+          MYSQL_USER: guardia
+          MYSQL_PASSWORD: testpassword
+          MYSQL_ROOT_PASSWORD: rootpassword
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h localhost"
+          --health-interval=5s
+          --health-timeout=3s
+          --health-retries=10
+
+    env:
+      FLASK_ENV: testing
+      SECRET_KEY: ci-integration-secret-not-for-prod
+      DATABASE_URL: mysql+pymysql://guardia:testpassword@127.0.0.1:3306/school_db
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: '3.13'
+          cache: 'pip'
+
+      - name: Upgrade pip
+        run: pip install --upgrade pip
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Run tests against MySQL
+        run: pytest tests/ -v --cov=app --cov-report=term --cov-report=xml
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        if: always()
+        with:
+          name: coverage-mysql
+          path: coverage.xml

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,7 +12,7 @@ jobs:
       db:
         image: mysql:8
         env:
-          MYSQL_DATABASE: school_db
+          MYSQL_DATABASE: guardia_db
           MYSQL_USER: guardia
           MYSQL_PASSWORD: testpassword
           MYSQL_ROOT_PASSWORD: rootpassword
@@ -27,7 +27,7 @@ jobs:
     env:
       FLASK_ENV: testing
       SECRET_KEY: ci-integration-secret-not-for-prod
-      DATABASE_URL: mysql+pymysql://guardia:testpassword@127.0.0.1:3306/school_db
+      DATABASE_URL: mysql+pymysql://guardia:testpassword@127.0.0.1:3306/guardia_db
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/TODO.md
+++ b/TODO.md
@@ -1,9 +1,0 @@
-# TODO list du projet intranet
-
-## Backend
-
-## Frontend
-
-## CI/CD
-
-- [ ] Ajouter le coverage du projet via des tests unitaires et d'intégration

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -78,4 +78,7 @@ def create_app(config=None):
 
     from .admin import admin_bp
     app.register_blueprint(admin_bp, url_prefix='/admin')
+
+    from .edt import edt_bp
+    app.register_blueprint(edt_bp, url_prefix='/edt')
     return app

--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -5,8 +5,8 @@ from flask import request, jsonify
 from flask_login import current_user, login_required
 from sqlalchemy.exc import IntegrityError
 from . import admin_bp
-from ..models import db, Direction, Log, User
-from ..decorators import role_required
+from ..models import db, Log, User
+from ..decorators import is_direction, role_required
 
 
 def _log(action, target_id=None):
@@ -62,14 +62,10 @@ def _generate_username(prenom, nom):
         i += 1
 
 
-def _is_direction():
-    return Direction.query.filter_by(id_user=current_user.id).first() is not None
-
-
 def _can_create(requested_type):
     if current_user.type == 'administrateur':
         return True
-    if current_user.type == 'employé' and _is_direction():
+    if current_user.type == 'employé' and is_direction():
         return requested_type in DIRECTION_TYPES
     return False
 
@@ -84,7 +80,7 @@ def list_users():
     query = User.query
 
     if current_user.type == 'employé':
-        if not _is_direction():
+        if not is_direction():
             return jsonify({'error': 'Accès refusé'}), 403
         query = query.filter(User.type.in_(DIRECTION_TYPES))
 
@@ -177,7 +173,7 @@ def update_user(user_id):
         return jsonify({'error': 'Utilisateur introuvable'}), 404
 
     if current_user.type == 'employé':
-        if not _is_direction() or user.type not in DIRECTION_TYPES:
+        if not is_direction() or user.type not in DIRECTION_TYPES:
             return jsonify({'error': 'Accès refusé'}), 403
     data = request.get_json(silent=True)
     if data is None:
@@ -236,7 +232,7 @@ def delete_user(user_id):
         return jsonify({'error': 'Utilisateur introuvable'}), 404
 
     if current_user.type == 'employé':
-        if not _is_direction() or user.type not in DIRECTION_TYPES:
+        if not is_direction() or user.type not in DIRECTION_TYPES:
             return jsonify({'error': 'Accès refusé'}), 403
 
     if user.id == current_user.id:

--- a/app/decorators.py
+++ b/app/decorators.py
@@ -3,6 +3,11 @@ from flask import jsonify
 from flask_login import current_user
 
 
+def is_direction():
+    from .models import Direction
+    return Direction.query.filter_by(id_user=current_user.id).first() is not None
+
+
 def role_required(*roles):
     def decorator(f):
         @wraps(f)

--- a/app/edt/__init__.py
+++ b/app/edt/__init__.py
@@ -1,0 +1,5 @@
+from flask import Blueprint
+
+edt_bp = Blueprint('edt', __name__)
+
+from . import routes  # noqa: F401, E402

--- a/app/edt/routes.py
+++ b/app/edt/routes.py
@@ -44,7 +44,10 @@ def _cours_to_dict(c):
 
 def _parse_dt(value):
     try:
-        return datetime.fromisoformat(value)
+        dt = datetime.fromisoformat(value)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt
     except (ValueError, TypeError):
         return None
 
@@ -109,6 +112,19 @@ def list_cours():
         query = query.filter(Cours.fin <= fin)
 
     cours = query.order_by(Cours.debut).all()
+
+    if current_user.type == 'administrateur' or (
+        current_user.type == 'employé' and is_direction()
+    ):
+        filters = []
+        if classe_id:
+            filters.append(f'classe_id={classe_id}')
+        if prof_id:
+            filters.append(f'prof_id={prof_id}')
+        if filters:
+            _log(f'cours_listed:{",".join(filters)}')
+            db.session.commit()
+
     return jsonify([_cours_to_dict(c) for c in cours]), 200
 
 
@@ -185,8 +201,10 @@ def update_cours(cours_id):
     changes = []
 
     if 'debut' in data or 'fin' in data:
-        debut = _parse_dt(data['debut']) if 'debut' in data else cours.debut
-        fin = _parse_dt(data['fin']) if 'fin' in data else cours.fin
+        def _norm(dt):
+            return dt.replace(tzinfo=timezone.utc) if dt and dt.tzinfo is None else dt
+        debut = _parse_dt(data['debut']) if 'debut' in data else _norm(cours.debut)
+        fin = _parse_dt(data['fin']) if 'fin' in data else _norm(cours.fin)
         if not debut or not fin:
             return jsonify({'error': 'Format de date invalide (ISO 8601 attendu)'}), 400
         if fin <= debut:

--- a/app/edt/routes.py
+++ b/app/edt/routes.py
@@ -52,6 +52,10 @@ def _parse_dt(value):
         return None
 
 
+def _norm_dt(dt):
+    return dt.replace(tzinfo=timezone.utc) if dt and dt.tzinfo is None else dt
+
+
 ALLOWED_ETATS = {'planifié', 'en cours', 'terminé', 'annulé'}
 
 
@@ -64,6 +68,7 @@ def list_cours():
     prof_id = request.args.get('prof_id', type=int)
 
     query = Cours.query
+    direction = current_user.type == 'employé' and is_direction()
 
     # scope automatique selon le rôle
     if current_user.type == 'élève':
@@ -79,7 +84,7 @@ def list_cours():
         query = query.filter(Cours.id_classe == parent.eleve.id_classe)
 
     elif current_user.type == 'employé':
-        if is_direction():
+        if direction:
             # direction : filtres libres comme admin
             if classe_id:
                 query = query.filter(Cours.id_classe == classe_id)
@@ -113,9 +118,7 @@ def list_cours():
 
     cours = query.order_by(Cours.debut).all()
 
-    if current_user.type == 'administrateur' or (
-        current_user.type == 'employé' and is_direction()
-    ):
+    if current_user.type == 'administrateur' or direction:
         filters = []
         if classe_id:
             filters.append(f'classe_id={classe_id}')
@@ -201,10 +204,8 @@ def update_cours(cours_id):
     changes = []
 
     if 'debut' in data or 'fin' in data:
-        def _norm(dt):
-            return dt.replace(tzinfo=timezone.utc) if dt and dt.tzinfo is None else dt
-        debut = _parse_dt(data['debut']) if 'debut' in data else _norm(cours.debut)
-        fin = _parse_dt(data['fin']) if 'fin' in data else _norm(cours.fin)
+        debut = _parse_dt(data['debut']) if 'debut' in data else _norm_dt(cours.debut)
+        fin = _parse_dt(data['fin']) if 'fin' in data else _norm_dt(cours.fin)
         if not debut or not fin:
             return jsonify({'error': 'Format de date invalide (ISO 8601 attendu)'}), 400
         if fin <= debut:

--- a/app/edt/routes.py
+++ b/app/edt/routes.py
@@ -1,0 +1,253 @@
+from datetime import datetime, timezone
+from flask import request, jsonify
+from flask_login import current_user, login_required
+from . import edt_bp
+from ..models import db, Classe, Cours, Eleve, Log, Matiere, Parent, Prof, Salle
+from ..decorators import is_direction, role_required
+
+
+def _log(action, target_id=None):
+    db.session.add(Log(
+        user_id=current_user.id,
+        action=action,
+        target_type='cours',
+        target_id=target_id,
+        ip_address=request.remote_addr,
+        user_agent=(request.user_agent.string or '')[:255],
+        created_at=datetime.now(timezone.utc)
+    ))
+
+
+def _cours_to_dict(c):
+    return {
+        'id': c.id,
+        'debut': c.debut.isoformat(),
+        'fin': c.fin.isoformat(),
+        'etat': c.etat,
+        'matiere': {'id': c.id_matiere, 'nom': c.matiere.nom if c.matiere else None},
+        'classe': {
+            'id': c.id_classe,
+            'niveau': c.classe.niveau if c.classe else None,
+            'suffixe': c.classe.suffixe if c.classe else None,
+        },
+        'prof': {
+            'id': c.id_prof,
+            'nom': c.prof.user.nom if c.prof and c.prof.user else None,
+            'prenom': c.prof.user.prenom if c.prof and c.prof.user else None,
+        },
+        'salle': {
+            'id': c.id_salle,
+            'nom': c.salle.nom if c.salle else None,
+        },
+    }
+
+
+def _parse_dt(value):
+    try:
+        return datetime.fromisoformat(value)
+    except (ValueError, TypeError):
+        return None
+
+
+ALLOWED_ETATS = {'planifié', 'en cours', 'terminé', 'annulé'}
+
+
+@edt_bp.get('/cours')
+@login_required
+def list_cours():
+    debut_str = request.args.get('debut')
+    fin_str = request.args.get('fin')
+    classe_id = request.args.get('classe_id', type=int)
+    prof_id = request.args.get('prof_id', type=int)
+
+    query = Cours.query
+
+    # scope automatique selon le rôle
+    if current_user.type == 'élève':
+        eleve = Eleve.query.filter_by(id_user=current_user.id).first()
+        if not eleve or not eleve.id_classe:
+            return jsonify([]), 200
+        query = query.filter(Cours.id_classe == eleve.id_classe)
+
+    elif current_user.type == 'parent':
+        parent = Parent.query.filter_by(id_user=current_user.id).first()
+        if not parent or not parent.eleve or not parent.eleve.id_classe:
+            return jsonify([]), 200
+        query = query.filter(Cours.id_classe == parent.eleve.id_classe)
+
+    elif current_user.type == 'employé':
+        if is_direction():
+            # direction : filtres libres comme admin
+            if classe_id:
+                query = query.filter(Cours.id_classe == classe_id)
+            if prof_id:
+                query = query.filter(Cours.id_prof == prof_id)
+        else:
+            # prof : uniquement ses cours
+            prof = Prof.query.filter_by(id_user=current_user.id).first()
+            if not prof:
+                return jsonify([]), 200
+            query = query.filter(Cours.id_prof == prof.id)
+
+    else:
+        # admin : filtres libres
+        if classe_id:
+            query = query.filter(Cours.id_classe == classe_id)
+        if prof_id:
+            query = query.filter(Cours.id_prof == prof_id)
+
+    if debut_str:
+        debut = _parse_dt(debut_str)
+        if not debut:
+            return jsonify({'error': 'Format de date invalide pour debut'}), 400
+        query = query.filter(Cours.debut >= debut)
+
+    if fin_str:
+        fin = _parse_dt(fin_str)
+        if not fin:
+            return jsonify({'error': 'Format de date invalide pour fin'}), 400
+        query = query.filter(Cours.fin <= fin)
+
+    cours = query.order_by(Cours.debut).all()
+    return jsonify([_cours_to_dict(c) for c in cours]), 200
+
+
+@edt_bp.post('/cours')
+@login_required
+@role_required('administrateur', 'employé')
+def create_cours():
+    if current_user.type == 'employé' and not is_direction():
+        return jsonify({'error': 'Accès refusé'}), 403
+
+    data = request.get_json(silent=True)
+    if data is None:
+        return jsonify({'error': 'JSON requis'}), 400
+
+    required = ['id_matiere', 'id_prof', 'id_classe', 'debut', 'fin']
+    missing = [f for f in required if not data.get(f)]
+    if missing:
+        return jsonify({'error': f'Champs requis : {", ".join(missing)}'}), 400
+
+    debut = _parse_dt(data['debut'])
+    fin = _parse_dt(data['fin'])
+    if not debut or not fin:
+        return jsonify({'error': 'Format de date invalide (ISO 8601 attendu)'}), 400
+    if fin <= debut:
+        return jsonify({'error': 'fin doit être après debut'}), 400
+
+    if not db.session.get(Matiere, data['id_matiere']):
+        return jsonify({'error': 'Matière introuvable'}), 404
+    if not db.session.get(Prof, data['id_prof']):
+        return jsonify({'error': 'Prof introuvable'}), 404
+    if not db.session.get(Classe, data['id_classe']):
+        return jsonify({'error': 'Classe introuvable'}), 404
+
+    id_salle = data.get('id_salle')
+    if id_salle and not db.session.get(Salle, id_salle):
+        return jsonify({'error': 'Salle introuvable'}), 404
+
+    etat = data.get('etat', 'planifié')
+    if etat not in ALLOWED_ETATS:
+        return jsonify({'error': 'État invalide'}), 400
+
+    cours = Cours(
+        id_matiere=data['id_matiere'],
+        id_prof=data['id_prof'],
+        id_classe=data['id_classe'],
+        debut=debut,
+        fin=fin,
+        etat=etat,
+        id_salle=id_salle
+    )
+    db.session.add(cours)
+    db.session.flush()
+    _log('cours_created', target_id=cours.id)
+    db.session.commit()
+
+    return jsonify(_cours_to_dict(cours)), 201
+
+
+@edt_bp.patch('/cours/<int:cours_id>')
+@login_required
+@role_required('administrateur', 'employé')
+def update_cours(cours_id):
+    if current_user.type == 'employé' and not is_direction():
+        return jsonify({'error': 'Accès refusé'}), 403
+
+    cours = db.session.get(Cours, cours_id)
+    if cours is None:
+        return jsonify({'error': 'Cours introuvable'}), 404
+
+    data = request.get_json(silent=True)
+    if data is None:
+        return jsonify({'error': 'JSON requis'}), 400
+
+    changes = []
+
+    if 'debut' in data or 'fin' in data:
+        debut = _parse_dt(data['debut']) if 'debut' in data else cours.debut
+        fin = _parse_dt(data['fin']) if 'fin' in data else cours.fin
+        if not debut or not fin:
+            return jsonify({'error': 'Format de date invalide (ISO 8601 attendu)'}), 400
+        if fin <= debut:
+            return jsonify({'error': 'fin doit être après debut'}), 400
+        cours.debut = debut
+        cours.fin = fin
+        changes.append('horaires')
+
+    if 'id_matiere' in data:
+        if not db.session.get(Matiere, data['id_matiere']):
+            return jsonify({'error': 'Matière introuvable'}), 404
+        cours.id_matiere = data['id_matiere']
+        changes.append('matiere')
+
+    if 'id_prof' in data:
+        if not db.session.get(Prof, data['id_prof']):
+            return jsonify({'error': 'Prof introuvable'}), 404
+        cours.id_prof = data['id_prof']
+        changes.append('prof')
+
+    if 'id_classe' in data:
+        if not db.session.get(Classe, data['id_classe']):
+            return jsonify({'error': 'Classe introuvable'}), 404
+        cours.id_classe = data['id_classe']
+        changes.append('classe')
+
+    if 'id_salle' in data:
+        id_salle = data['id_salle']
+        if id_salle and not db.session.get(Salle, id_salle):
+            return jsonify({'error': 'Salle introuvable'}), 404
+        cours.id_salle = id_salle
+        changes.append('salle')
+
+    if 'etat' in data:
+        if data['etat'] not in ALLOWED_ETATS:
+            return jsonify({'error': 'État invalide'}), 400
+        cours.etat = data['etat']
+        changes.append('etat')
+
+    if not changes:
+        return jsonify({'error': 'Aucun champ modifiable fourni'}), 400
+
+    _log(f'cours_updated:{",".join(changes)}', target_id=cours.id)
+    db.session.commit()
+
+    return jsonify(_cours_to_dict(cours)), 200
+
+
+@edt_bp.delete('/cours/<int:cours_id>')
+@login_required
+@role_required('administrateur', 'employé')
+def delete_cours(cours_id):
+    if current_user.type == 'employé' and not is_direction():
+        return jsonify({'error': 'Accès refusé'}), 403
+
+    cours = db.session.get(Cours, cours_id)
+    if cours is None:
+        return jsonify({'error': 'Cours introuvable'}), 404
+
+    _log('cours_deleted', target_id=cours.id)
+    db.session.delete(cours)
+    db.session.commit()
+
+    return jsonify({'message': 'Cours supprimé'}), 200

--- a/app/edt/routes.py
+++ b/app/edt/routes.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timezone
 from flask import request, jsonify
 from flask_login import current_user, login_required
+from sqlalchemy.orm import joinedload
 from . import edt_bp
 from ..models import db, Classe, Cours, Eleve, Log, Matiere, Parent, Prof, Salle
 from ..decorators import is_direction, role_required
@@ -44,6 +45,8 @@ def _cours_to_dict(c):
 
 def _parse_dt(value):
     try:
+        if isinstance(value, str):
+            value = value.replace('Z', '+00:00')
         dt = datetime.fromisoformat(value)
         if dt.tzinfo is None:
             dt = dt.replace(tzinfo=timezone.utc)
@@ -67,7 +70,12 @@ def list_cours():
     classe_id = request.args.get('classe_id', type=int)
     prof_id = request.args.get('prof_id', type=int)
 
-    query = Cours.query
+    query = Cours.query.options(
+        joinedload(Cours.matiere),
+        joinedload(Cours.classe),
+        joinedload(Cours.prof).joinedload(Prof.user),
+        joinedload(Cours.salle),
+    )
     direction = current_user.type == 'employé' and is_direction()
 
     # scope automatique selon le rôle

--- a/app/models.py
+++ b/app/models.py
@@ -67,6 +67,7 @@ class Prof(db.Model):
         db.Integer, db.ForeignKey('user.id', ondelete='CASCADE'), nullable=False
     )
     matieres = db.relationship('Matiere', secondary=prof_matiere, backref='profs')
+    user = db.relationship('User', foreign_keys=[id_user])
 
 
 class Classe(db.Model):
@@ -116,6 +117,7 @@ class Parent(db.Model):
     id_information = db.Column(
         db.Integer, db.ForeignKey('information.id', ondelete='SET NULL'), nullable=True
     )
+    eleve = db.relationship('Eleve', foreign_keys=[id_eleve])
 
 
 class Employe(db.Model):
@@ -204,6 +206,10 @@ class Cours(db.Model):
     id_salle = db.Column(
         db.Integer, db.ForeignKey('salle.id', ondelete='SET NULL'), nullable=True
     )
+    matiere = db.relationship('Matiere', foreign_keys=[id_matiere])
+    prof = db.relationship('Prof', foreign_keys=[id_prof])
+    classe = db.relationship('Classe', foreign_keys=[id_classe])
+    salle = db.relationship('Salle', foreign_keys=[id_salle])
 
 
 class Devoir(db.Model):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,14 @@
+import os
 import pytest
 from app import bcrypt, create_app
 from app.models import Direction, User, db
 
+_DB_URI = os.environ.get('DATABASE_URL', 'sqlite:///:memory:')
+
 
 @pytest.fixture
 def app():
-    app = create_app({'TESTING': True, 'SQLALCHEMY_DATABASE_URI': 'sqlite:///:memory:'})
+    app = create_app({'TESTING': True, 'SQLALCHEMY_DATABASE_URI': _DB_URI})
 
     with app.app_context():
         db.create_all()

--- a/tests/test_edt.py
+++ b/tests/test_edt.py
@@ -1,0 +1,373 @@
+import pytest
+from datetime import datetime
+from app import bcrypt
+from app.models import (
+    Batiment, Classe, Cours, Direction, Eleve, Etage,
+    Matiere, Parent, Prof, Salle, User, db
+)
+
+
+@pytest.fixture
+def admin(app):
+    with app.app_context():
+        u = User(
+            type='administrateur', nom='Admin', prenom='Test',
+            username='admin_edt',
+            mail_interne='admin.edt@guardiaschool.fr',
+            password=bcrypt.generate_password_hash('adminpass').decode('utf-8')
+        )
+        db.session.add(u)
+        db.session.commit()
+        yield u
+
+
+@pytest.fixture
+def direction_user(app):
+    with app.app_context():
+        u = User(
+            type='employé', nom='Dir', prenom='Chef',
+            username='dir_edt',
+            mail_interne='dir.edt@guardiaschool.fr',
+            password=bcrypt.generate_password_hash('dirpass').decode('utf-8')
+        )
+        db.session.add(u)
+        db.session.flush()
+        db.session.add(Direction(id_user=u.id))
+        db.session.commit()
+        yield u
+
+
+@pytest.fixture
+def setup(app):
+    """Crée matière, classe, prof, salle et un cours."""
+    with app.app_context():
+        matiere = Matiere(nom='Mathématiques')
+        db.session.add(matiere)
+
+        classe = Classe(niveau=1, suffixe='A', annee=2026)
+        db.session.add(classe)
+
+        prof_user = User(
+            type='employé', nom='Prof', prenom='Jean',
+            username='jprof',
+            mail_interne='jean.prof@guardiaschool.fr',
+            password=bcrypt.generate_password_hash('profpass').decode('utf-8')
+        )
+        db.session.add(prof_user)
+        db.session.flush()
+
+        prof = Prof(id_user=prof_user.id)
+        db.session.add(prof)
+
+        batiment = Batiment(nom='Bâtiment A')
+        db.session.add(batiment)
+        db.session.flush()
+
+        etage = Etage(numero=1, id_batiment=batiment.id)
+        db.session.add(etage)
+        db.session.flush()
+
+        salle = Salle(nom='A101', id_etage=etage.id)
+        db.session.add(salle)
+        db.session.flush()
+
+        cours = Cours(
+            id_matiere=matiere.id,
+            id_prof=prof.id,
+            id_classe=classe.id,
+            debut=datetime(2026, 4, 7, 8, 0),
+            fin=datetime(2026, 4, 7, 10, 0),
+            etat='planifié',
+            id_salle=salle.id
+        )
+        db.session.add(cours)
+        db.session.commit()
+
+        yield {
+            'matiere': matiere,
+            'classe': classe,
+            'prof': prof,
+            'prof_user': prof_user,
+            'salle': salle,
+            'cours': cours,
+        }
+
+
+@pytest.fixture
+def eleve_user(app, setup):
+    with app.app_context():
+        u = User(
+            type='élève', nom='Dupont', prenom='Jean',
+            username='jdupont_edt',
+            mail_interne='jean.dupont.edt@guardiaschool.fr',
+            password=bcrypt.generate_password_hash('elevepass').decode('utf-8')
+        )
+        db.session.add(u)
+        db.session.flush()
+        eleve = Eleve(id_user=u.id, id_classe=setup['classe'].id)
+        db.session.add(eleve)
+        db.session.commit()
+        yield u
+
+
+@pytest.fixture
+def parent_user(app, setup, eleve_user):
+    with app.app_context():
+        eleve = Eleve.query.filter_by(id_user=eleve_user.id).first()
+        u = User(
+            type='parent', nom='Dupont', prenom='Marie',
+            username='mdupont_edt',
+            mail_interne='marie.dupont.edt@guardiaschool.fr',
+            password=bcrypt.generate_password_hash('parentpass').decode('utf-8')
+        )
+        db.session.add(u)
+        db.session.flush()
+        parent = Parent(id_user=u.id, id_eleve=eleve.id)
+        db.session.add(parent)
+        db.session.commit()
+        yield u
+
+
+# --- GET /edt/cours ---
+
+def test_list_cours_admin(client, admin, setup):
+    # admin voit tous les cours
+    client.post('/auth/login', json={
+        'email': 'admin.edt@guardiaschool.fr', 'password': 'adminpass'
+    })
+    response = client.get('/edt/cours')
+    assert response.status_code == 200
+    data = response.get_json()
+    assert isinstance(data, list)
+    assert len(data) == 1
+
+
+def test_list_cours_eleve_scope(client, eleve_user, setup):
+    # élève voit uniquement les cours de sa classe
+    client.post('/auth/login', json={
+        'email': 'jean.dupont.edt@guardiaschool.fr', 'password': 'elevepass'
+    })
+    response = client.get('/edt/cours')
+    assert response.status_code == 200
+    data = response.get_json()
+    assert all(c['classe']['id'] == setup['classe'].id for c in data)
+
+
+def test_list_cours_parent_scope(client, parent_user, setup):
+    # parent voit les cours de la classe de son enfant
+    client.post('/auth/login', json={
+        'email': 'marie.dupont.edt@guardiaschool.fr', 'password': 'parentpass'
+    })
+    response = client.get('/edt/cours')
+    assert response.status_code == 200
+    data = response.get_json()
+    assert all(c['classe']['id'] == setup['classe'].id for c in data)
+
+
+def test_list_cours_direction_sees_all(client, direction_user, setup):
+    # direction voit tous les cours sans restriction
+    client.post('/auth/login', json={
+        'email': 'dir.edt@guardiaschool.fr', 'password': 'dirpass'
+    })
+    response = client.get('/edt/cours')
+    assert response.status_code == 200
+    assert len(response.get_json()) == 1
+
+
+def test_list_cours_filter_debut(client, admin, setup):
+    # filtre par debut : aucun cours après le 8 avril
+    client.post('/auth/login', json={
+        'email': 'admin.edt@guardiaschool.fr', 'password': 'adminpass'
+    })
+    response = client.get('/edt/cours?debut=2026-04-08T00:00:00')
+    assert response.status_code == 200
+    assert response.get_json() == []
+
+
+def test_list_cours_invalid_date(client, admin, setup):
+    # date invalide en querystring => 400
+    client.post('/auth/login', json={
+        'email': 'admin.edt@guardiaschool.fr', 'password': 'adminpass'
+    })
+    response = client.get('/edt/cours?debut=pas-une-date')
+    assert response.status_code == 400
+
+
+def test_list_cours_unauthenticated(client):
+    response = client.get('/edt/cours')
+    assert response.status_code == 401
+
+
+# --- POST /edt/cours ---
+
+def test_create_cours_success(client, admin, setup):
+    client.post('/auth/login', json={
+        'email': 'admin.edt@guardiaschool.fr', 'password': 'adminpass'
+    })
+    response = client.post('/edt/cours', json={
+        'id_matiere': setup['matiere'].id,
+        'id_prof': setup['prof'].id,
+        'id_classe': setup['classe'].id,
+        'debut': '2026-04-08T08:00:00',
+        'fin': '2026-04-08T10:00:00',
+    })
+    assert response.status_code == 201
+    data = response.get_json()
+    assert data['etat'] == 'planifié'
+    assert data['matiere']['nom'] == 'Mathématiques'
+
+
+def test_create_cours_missing_fields(client, admin, setup):
+    client.post('/auth/login', json={
+        'email': 'admin.edt@guardiaschool.fr', 'password': 'adminpass'
+    })
+    response = client.post('/edt/cours', json={
+        'id_matiere': setup['matiere'].id,
+    })
+    assert response.status_code == 400
+
+
+def test_create_cours_fin_before_debut(client, admin, setup):
+    client.post('/auth/login', json={
+        'email': 'admin.edt@guardiaschool.fr', 'password': 'adminpass'
+    })
+    response = client.post('/edt/cours', json={
+        'id_matiere': setup['matiere'].id,
+        'id_prof': setup['prof'].id,
+        'id_classe': setup['classe'].id,
+        'debut': '2026-04-08T10:00:00',
+        'fin': '2026-04-08T08:00:00',
+    })
+    assert response.status_code == 400
+
+
+def test_create_cours_invalid_etat(client, admin, setup):
+    client.post('/auth/login', json={
+        'email': 'admin.edt@guardiaschool.fr', 'password': 'adminpass'
+    })
+    response = client.post('/edt/cours', json={
+        'id_matiere': setup['matiere'].id,
+        'id_prof': setup['prof'].id,
+        'id_classe': setup['classe'].id,
+        'debut': '2026-04-08T08:00:00',
+        'fin': '2026-04-08T10:00:00',
+        'etat': 'inconnu',
+    })
+    assert response.status_code == 400
+
+
+def test_create_cours_non_direction_forbidden(client, app, setup):
+    # employé non-direction => 403
+    with app.app_context():
+        u = User(
+            type='employé', nom='Cantine', prenom='Agent',
+            username='cantine_edt',
+            mail_interne='cantine.edt@guardiaschool.fr',
+            password=bcrypt.generate_password_hash('cantinepass').decode('utf-8')
+        )
+        db.session.add(u)
+        db.session.commit()
+    client.post('/auth/login', json={
+        'email': 'cantine.edt@guardiaschool.fr', 'password': 'cantinepass'
+    })
+    response = client.post('/edt/cours', json={
+        'id_matiere': setup['matiere'].id,
+        'id_prof': setup['prof'].id,
+        'id_classe': setup['classe'].id,
+        'debut': '2026-04-08T08:00:00',
+        'fin': '2026-04-08T10:00:00',
+    })
+    assert response.status_code == 403
+
+
+def test_create_cours_eleve_forbidden(client, eleve_user, setup):
+    client.post('/auth/login', json={
+        'email': 'jean.dupont.edt@guardiaschool.fr', 'password': 'elevepass'
+    })
+    response = client.post('/edt/cours', json={
+        'id_matiere': setup['matiere'].id,
+        'id_prof': setup['prof'].id,
+        'id_classe': setup['classe'].id,
+        'debut': '2026-04-08T08:00:00',
+        'fin': '2026-04-08T10:00:00',
+    })
+    assert response.status_code == 403
+
+
+def test_create_cours_unauthenticated(client, setup):
+    response = client.post('/edt/cours', json={
+        'id_matiere': setup['matiere'].id,
+        'id_prof': setup['prof'].id,
+        'id_classe': setup['classe'].id,
+        'debut': '2026-04-08T08:00:00',
+        'fin': '2026-04-08T10:00:00',
+    })
+    assert response.status_code == 401
+
+
+# --- PATCH /edt/cours/<id> ---
+
+def test_update_cours_success(client, admin, setup):
+    client.post('/auth/login', json={
+        'email': 'admin.edt@guardiaschool.fr', 'password': 'adminpass'
+    })
+    response = client.patch(f'/edt/cours/{setup["cours"].id}', json={
+        'etat': 'annulé'
+    })
+    assert response.status_code == 200
+    assert response.get_json()['etat'] == 'annulé'
+
+
+def test_update_cours_not_found(client, admin):
+    client.post('/auth/login', json={
+        'email': 'admin.edt@guardiaschool.fr', 'password': 'adminpass'
+    })
+    response = client.patch('/edt/cours/9999', json={'etat': 'annulé'})
+    assert response.status_code == 404
+
+
+def test_update_cours_no_fields(client, admin, setup):
+    client.post('/auth/login', json={
+        'email': 'admin.edt@guardiaschool.fr', 'password': 'adminpass'
+    })
+    response = client.patch(f'/edt/cours/{setup["cours"].id}', json={})
+    assert response.status_code == 400
+
+
+def test_update_cours_forbidden(client, eleve_user, setup):
+    client.post('/auth/login', json={
+        'email': 'jean.dupont.edt@guardiaschool.fr', 'password': 'elevepass'
+    })
+    response = client.patch(f'/edt/cours/{setup["cours"].id}', json={'etat': 'annulé'})
+    assert response.status_code == 403
+
+
+# --- DELETE /edt/cours/<id> ---
+
+def test_delete_cours_success(client, admin, setup):
+    client.post('/auth/login', json={
+        'email': 'admin.edt@guardiaschool.fr', 'password': 'adminpass'
+    })
+    response = client.delete(f'/edt/cours/{setup["cours"].id}')
+    assert response.status_code == 200
+
+
+def test_delete_cours_not_found(client, admin):
+    client.post('/auth/login', json={
+        'email': 'admin.edt@guardiaschool.fr', 'password': 'adminpass'
+    })
+    response = client.delete('/edt/cours/9999')
+    assert response.status_code == 404
+
+
+def test_delete_cours_forbidden(client, eleve_user, setup):
+    client.post('/auth/login', json={
+        'email': 'jean.dupont.edt@guardiaschool.fr', 'password': 'elevepass'
+    })
+    response = client.delete(f'/edt/cours/{setup["cours"].id}')
+    assert response.status_code == 403
+
+
+def test_delete_cours_unauthenticated(client, setup):
+    response = client.delete(f'/edt/cours/{setup["cours"].id}')
+    assert response.status_code == 401

--- a/tests/test_edt.py
+++ b/tests/test_edt.py
@@ -193,6 +193,18 @@ def test_list_cours_invalid_date(client, admin, setup):
     assert response.status_code == 400
 
 
+def test_list_cours_prof_scope(client, setup):
+    # prof voit uniquement ses propres cours
+    client.post('/auth/login', json={
+        'email': 'jean.prof@guardiaschool.fr', 'password': 'profpass'
+    })
+    response = client.get('/edt/cours')
+    assert response.status_code == 200
+    data = response.get_json()
+    assert len(data) == 1
+    assert data[0]['prof']['id'] == setup['prof'].id
+
+
 def test_list_cours_unauthenticated(client):
     response = client.get('/edt/cours')
     assert response.status_code == 401
@@ -332,6 +344,28 @@ def test_update_cours_no_fields(client, admin, setup):
     })
     response = client.patch(f'/edt/cours/{setup["cours"].id}', json={})
     assert response.status_code == 400
+
+
+def test_update_cours_partial_debut_only(client, admin, setup):
+    client.post('/auth/login', json={
+        'email': 'admin.edt@guardiaschool.fr', 'password': 'adminpass'
+    })
+    response = client.patch(f'/edt/cours/{setup["cours"].id}', json={
+        'debut': '2026-04-07T09:00:00',
+    })
+    assert response.status_code == 200
+    assert response.get_json()['debut'].startswith('2026-04-07T09:00:00')
+
+
+def test_update_cours_partial_fin_only(client, admin, setup):
+    client.post('/auth/login', json={
+        'email': 'admin.edt@guardiaschool.fr', 'password': 'adminpass'
+    })
+    response = client.patch(f'/edt/cours/{setup["cours"].id}', json={
+        'fin': '2026-04-07T11:00:00',
+    })
+    assert response.status_code == 200
+    assert response.get_json()['fin'].startswith('2026-04-07T11:00:00')
 
 
 def test_update_cours_forbidden(client, eleve_user, setup):

--- a/tests/test_edt.py
+++ b/tests/test_edt.py
@@ -292,6 +292,20 @@ def test_create_cours_non_direction_forbidden(client, app, setup):
     assert response.status_code == 403
 
 
+def test_create_cours_direction_allowed(client, direction_user, setup):
+    client.post('/auth/login', json={
+        'email': 'dir.edt@guardiaschool.fr', 'password': 'dirpass'
+    })
+    response = client.post('/edt/cours', json={
+        'id_matiere': setup['matiere'].id,
+        'id_prof': setup['prof'].id,
+        'id_classe': setup['classe'].id,
+        'debut': '2026-04-08T08:00:00',
+        'fin': '2026-04-08T10:00:00',
+    })
+    assert response.status_code == 201
+
+
 def test_create_cours_eleve_forbidden(client, eleve_user, setup):
     client.post('/auth/login', json={
         'email': 'jean.dupont.edt@guardiaschool.fr', 'password': 'elevepass'
@@ -346,6 +360,16 @@ def test_update_cours_no_fields(client, admin, setup):
     assert response.status_code == 400
 
 
+def test_update_cours_direction_allowed(client, direction_user, setup):
+    client.post('/auth/login', json={
+        'email': 'dir.edt@guardiaschool.fr', 'password': 'dirpass'
+    })
+    response = client.patch(f'/edt/cours/{setup["cours"].id}', json={
+        'etat': 'annulé'
+    })
+    assert response.status_code == 200
+
+
 def test_update_cours_partial_debut_only(client, admin, setup):
     client.post('/auth/login', json={
         'email': 'admin.edt@guardiaschool.fr', 'password': 'adminpass'
@@ -392,6 +416,14 @@ def test_delete_cours_not_found(client, admin):
     })
     response = client.delete('/edt/cours/9999')
     assert response.status_code == 404
+
+
+def test_delete_cours_direction_allowed(client, direction_user, setup):
+    client.post('/auth/login', json={
+        'email': 'dir.edt@guardiaschool.fr', 'password': 'dirpass'
+    })
+    response = client.delete(f'/edt/cours/{setup["cours"].id}')
+    assert response.status_code == 200
 
 
 def test_delete_cours_forbidden(client, eleve_user, setup):


### PR DESCRIPTION
## Summary

- `GET /edt/cours` — scope automatique par rôle : élève voit sa classe, parent voit la classe de son enfant, prof voit ses cours, direction/admin voient tout avec filtres libres (`classe_id`, `prof_id`, `debut`, `fin`)
- `POST /edt/cours` — direction et admin uniquement
- `PATCH /edt/cours/<id>` — direction et admin uniquement
- `DELETE /edt/cours/<id>` — direction et admin uniquement
- `is_direction()` mutualisé dans `decorators.py` (refactor depuis admin/routes.py)
- Relations ORM ajoutées sur `Prof`, `Cours`, `Parent`

Closes #50
Closes #51

## Test plan

- [x] 75 tests passent (`pytest tests/`)
- [x] Flake8 sans erreur
- [x] Tester `GET /edt/cours` en tant qu'élève → retourne uniquement sa classe
- [x] Tester `POST /edt/cours` en tant qu'employé non-direction → 403
- [x] Tester `GET /edt/cours?debut=pas-une-date` → 400