### PR TITLE
docs: documentation API pour le frontend

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -7,21 +7,37 @@ on:
       - develop
     tags:
       - 'v*.*.*'
-    paths-ignore:
-      - 'README.md'
-      - 'docs/**'
 
   pull_request:
     branches:
       - main
       - develop
-    paths-ignore:
-      - 'README.md'
-      - 'docs/**'
 
 jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.check.outputs.code }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - name: Check if code files changed
+        id: check
+        run: |
+          BASE=${{ github.event.pull_request.base.sha || github.event.before }}
+          if git diff --name-only "$BASE" HEAD | grep -qE '^(app/|tests/|requirements\.txt|Dockerfile)'; then
+            echo "code=true" >> $GITHUB_OUTPUT
+          else
+            echo "code=false" >> $GITHUB_OUTPUT
+          fi
+
   lint:
     name: Lint Flask Code
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -31,7 +47,7 @@ jobs:
         with:
           python-version: '3.13'
           cache: 'pip'
-      
+
       - name: Upgrade pip
         run: pip install --upgrade pip
 
@@ -43,6 +59,8 @@ jobs:
 
   test:
     name: Flask tests
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     env:
       FLASK_ENV: testing
@@ -65,9 +83,11 @@ jobs:
 
       - name: run tests
         run: pytest tests/ --cov=app --cov-report=term --cov-report=xml
-  
+
   pip-audit:
     name: Pip Audit Scan
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -76,7 +96,7 @@ jobs:
         with:
           python-version: '3.13'
           cache: 'pip'
-      
+
       - name: upgrade pip
         run: pip install --upgrade pip
 
@@ -97,6 +117,10 @@ jobs:
     name: build Docker image
     runs-on: ubuntu-latest
     needs: [lint, test, pip-audit]
+    if: |
+      always() &&
+      !contains(needs.*.result, 'failure') &&
+      !contains(needs.*.result, 'cancelled')
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -128,7 +152,7 @@ jobs:
             echo "Waiting... ($i/30)"
             sleep 2
           done
-        
+
       - name: run scan
         uses: zaproxy/action-baseline@de8ad967d3548d44ef623df22cf95c3b0baf8b25 # v0.15.0
         with:
@@ -144,5 +168,17 @@ jobs:
           path: report_html.html
 
       - name: stop app
-        if: always()  
+        if: always()
         run: docker compose -f docker-compose.yml down
+
+  ci-status:
+    name: CI
+    runs-on: ubuntu-latest
+    needs: [lint, test, pip-audit, build]
+    if: always()
+    steps:
+      - name: Verifier que tous les jobs ont reussi ou ete skipped
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" || "${{ contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            exit 1
+          fi

--- a/docs/api/admin.md
+++ b/docs/api/admin.md
@@ -1,0 +1,155 @@
+# API — Administration
+
+> Dernière mise à jour : 3 avril 2026
+> Blueprint : `admin_bp` — préfixe `/admin`
+
+**Auth requise sur toutes les routes** : oui (`administrateur` ou `employé` direction).
+
+---
+
+## RBAC
+
+| Rôle | Périmètre |
+|---|---|
+| `administrateur` | Tous les types d'utilisateurs |
+| `employé` (direction uniquement) | `élève` et `parent` uniquement |
+| Autres | 403 |
+
+---
+
+## Routes
+
+### GET /admin/users
+
+Liste les utilisateurs avec filtres optionnels.
+
+**Query params :**
+| Param | Type | Description |
+|---|---|---|
+| `type` | string | Filtre par type (`élève`, `employé`, `parent`, `administrateur`) |
+| `search` | string | Recherche sur `nom`, `prenom`, `username` (insensible à la casse) |
+
+**Réponse 200 :**
+```json
+[
+  {
+    "id": 1,
+    "nom": "Martin",
+    "prenom": "Alice",
+    "username": "amartin",
+    "type": "élève",
+    "is_active": true
+  }
+]
+```
+
+**Réponses :**
+| Code | Cas |
+|---|---|
+| 200 | Liste (vide si aucun résultat) |
+| 401 | Non authentifié |
+| 403 | Rôle insuffisant ou employé hors direction |
+
+---
+
+### POST /admin/users
+
+Crée un nouveau compte utilisateur. Le mot de passe n'est pas défini à la création — un `setup_token` valable 48h est retourné pour que l'utilisateur configure son mot de passe via `POST /auth/setup-password`.
+
+**Corps (JSON) :**
+```json
+{
+  "nom": "string",
+  "prenom": "string",
+  "type": "élève | employé | parent | administrateur"
+}
+```
+
+**Comportement :**
+- `mail_interne` généré automatiquement : `prenom.nom@guardiaschool.fr` (déduplication si collision)
+- `username` généré automatiquement : initiale prénom + nom (déduplication si collision)
+- `setup_token` à transmettre à l'utilisateur pour qu'il définisse son mot de passe
+
+**Réponse 201 :**
+```json
+{
+  "id": 42,
+  "mail_interne": "alice.martin@guardiaschool.fr",
+  "username": "amartin",
+  "setup_token": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+}
+```
+
+**Réponses :**
+| Code | Cas |
+|---|---|
+| 201 | Compte créé |
+| 400 | Champs manquants ou type invalide |
+| 401 | Non authentifié |
+| 403 | Rôle insuffisant ou type non autorisé pour la direction |
+| 500 | Impossible de générer un identifiant unique (rare) |
+
+---
+
+### PATCH /admin/users/\<user_id\>
+
+Modifie un compte existant. Seuls les champs fournis sont mis à jour.
+
+**Corps (JSON) — tous optionnels, au moins un requis :**
+```json
+{
+  "nom": "string",
+  "prenom": "string",
+  "type": "élève | employé | parent | administrateur",
+  "is_active": true
+}
+```
+
+**Réponse 200 :**
+```json
+{
+  "id": 42,
+  "nom": "Martin",
+  "prenom": "Alice",
+  "type": "élève",
+  "is_active": true
+}
+```
+
+**Réponses :**
+| Code | Cas |
+|---|---|
+| 200 | Compte mis à jour |
+| 400 | Aucun champ valide, champ vide, type invalide, `is_active` non booléen |
+| 401 | Non authentifié |
+| 403 | Rôle insuffisant |
+| 404 | Utilisateur introuvable |
+
+---
+
+### DELETE /admin/users/\<user_id\>
+
+Supprime définitivement un compte.
+
+**Contraintes :**
+- Impossible de supprimer son propre compte (→ 403)
+- Direction : uniquement les comptes `élève` et `parent`
+
+**Réponses :**
+| Code | Cas |
+|---|---|
+| 200 | `{ "message": "Compte supprimé" }` |
+| 401 | Non authentifié |
+| 403 | Rôle insuffisant ou tentative d'auto-suppression |
+| 404 | Utilisateur introuvable |
+
+---
+
+## Flux typique — création d'un compte
+
+```
+1. Admin  →  POST /admin/users          →  reçoit setup_token
+2. Admin  →  transmet le setup_token à l'utilisateur (email externe, etc.)
+3. User   →  POST /auth/setup-password  →  définit son mot de passe
+4. User   →  POST /auth/login           →  connecté
+```

--- a/docs/api/auth.md
+++ b/docs/api/auth.md
@@ -1,6 +1,6 @@
 # API — Auth & Profils
 
-> Dernière mise à jour : 30 mars 2026
+> Dernière mise à jour : 3 avril 2026
 > Blueprint : `auth_bp` — préfixe `/auth`
 
 ---
@@ -16,7 +16,7 @@ Authentifie un utilisateur et ouvre une session.
 **Corps (JSON) :**
 ```json
 {
-  "username": "string",
+  "email": "string (mail interne, ex: prenom.nom@guardiaschool.fr)",
   "password": "string"
 }
 ```
@@ -126,6 +126,33 @@ Crée une entrée `Mail` avec objet et corps pré-remplis (identité de l'expéd
 | 400 | Champ non autorisé |
 | 404 | Aucun responsable direction en base |
 | 401 | Non authentifié |
+
+### POST /auth/setup-password
+
+Permet à un nouvel utilisateur de définir son mot de passe via le lien de setup envoyé par l'admin.
+
+**Auth requise :** non
+
+**Rate limit :** 5 requêtes / minute par IP.
+
+**Corps (JSON) :**
+```json
+{
+  "token": "string (token reçu par l'admin à la création du compte)",
+  "password": "string (min. 8 caractères)"
+}
+```
+
+**Validations :**
+- `token` vérifié en base (`setup_token`) et non expiré (`setup_token_expires`)
+- `password` : minimum 8 caractères
+- Après succès : `setup_token` et `setup_token_expires` remis à `null`
+
+**Réponses :**
+| Code | Cas |
+|---|---|
+| 200 | Mot de passe configuré |
+| 400 | Token ou password manquant, password trop court, lien invalide ou expiré |
 
 ---
 

--- a/docs/api/edt.md
+++ b/docs/api/edt.md
@@ -1,0 +1,173 @@
+# API — Emploi du temps
+
+> Dernière mise à jour : 3 avril 2026
+> Blueprint : `edt_bp` — préfixe `/edt`
+
+**Auth requise sur toutes les routes** : oui.
+
+---
+
+## RBAC — Scopes automatiques sur GET
+
+| Rôle | Données visibles |
+|---|---|
+| `élève` | Cours de sa classe uniquement |
+| `parent` | Cours de la classe de son élève |
+| `employé` (prof) | Ses cours uniquement |
+| `employé` (direction) | Tous les cours, filtres libres |
+| `administrateur` | Tous les cours, filtres libres |
+
+Les routes POST / PATCH / DELETE sont réservées à `administrateur` et `employé` direction.
+
+---
+
+## Format d'une date
+
+Toutes les dates sont en **ISO 8601** avec timezone. Exemples acceptés :
+```
+2026-04-07T08:00:00+02:00
+2026-04-07T08:00:00Z
+2026-04-07T08:00:00
+```
+
+---
+
+## Routes
+
+### GET /edt/cours
+
+Retourne la liste des cours selon le scope du rôle connecté.
+
+**Query params (admin et direction uniquement) :**
+| Param | Type | Description |
+|---|---|---|
+| `debut` | datetime ISO 8601 | Filtre les cours dont `debut >= valeur` |
+| `fin` | datetime ISO 8601 | Filtre les cours dont `fin <= valeur` |
+| `classe_id` | integer | Filtre par classe |
+| `prof_id` | integer | Filtre par professeur |
+
+**Réponse 200 :**
+```json
+[
+  {
+    "id": 1,
+    "debut": "2026-04-07T08:00:00+00:00",
+    "fin": "2026-04-07T10:00:00+00:00",
+    "etat": "planifié",
+    "matiere": { "id": 3, "nom": "Mathématiques" },
+    "classe": { "id": 2, "niveau": 1, "suffixe": "A" },
+    "prof": { "id": 5, "nom": "Dupont", "prenom": "Paul" },
+    "salle": { "id": 7, "nom": "Salle 101" }
+  }
+]
+```
+
+**Réponses :**
+| Code | Cas |
+|---|---|
+| 200 | Liste (vide si aucun résultat) |
+| 400 | Format de date invalide |
+| 401 | Non authentifié |
+
+---
+
+### POST /edt/cours
+
+Crée un nouveau cours.
+
+**Rôles autorisés :** `administrateur`, `employé` direction.
+
+**Corps (JSON) :**
+```json
+{
+  "id_matiere": 3,
+  "id_prof": 5,
+  "id_classe": 2,
+  "debut": "2026-04-07T08:00:00Z",
+  "fin": "2026-04-07T10:00:00Z",
+  "id_salle": 7,
+  "etat": "planifié"
+}
+```
+
+| Champ | Requis | Description |
+|---|---|---|
+| `id_matiere` | oui | ID d'une `Matiere` existante |
+| `id_prof` | oui | ID d'un `Prof` existant |
+| `id_classe` | oui | ID d'une `Classe` existante |
+| `debut` | oui | ISO 8601 |
+| `fin` | oui | ISO 8601, doit être après `debut` |
+| `id_salle` | non | ID d'une `Salle` existante |
+| `etat` | non | `planifié` (défaut), `en cours`, `terminé`, `annulé` |
+
+**Réponse 201 :** objet cours complet (même format que GET).
+
+**Réponses :**
+| Code | Cas |
+|---|---|
+| 201 | Cours créé |
+| 400 | Champs manquants, date invalide, `fin` avant `debut`, état invalide |
+| 401 | Non authentifié |
+| 403 | Rôle insuffisant |
+| 404 | Matière, prof, classe ou salle introuvable |
+
+---
+
+### PATCH /edt/cours/\<cours_id\>
+
+Modifie un cours existant. Seuls les champs fournis sont mis à jour.
+
+**Rôles autorisés :** `administrateur`, `employé` direction.
+
+**Corps (JSON) — tous optionnels, au moins un requis :**
+```json
+{
+  "debut": "2026-04-07T09:00:00Z",
+  "fin": "2026-04-07T11:00:00Z",
+  "id_matiere": 3,
+  "id_prof": 5,
+  "id_classe": 2,
+  "id_salle": 7,
+  "etat": "annulé"
+}
+```
+
+**Note :** si `debut` ou `fin` est fourni, les deux sont recalculés ensemble — la cohérence `fin > debut` est toujours vérifiée.
+
+**Réponse 200 :** objet cours complet mis à jour.
+
+**Réponses :**
+| Code | Cas |
+|---|---|
+| 200 | Cours mis à jour |
+| 400 | Aucun champ valide, date invalide, `fin` avant `debut`, état invalide |
+| 401 | Non authentifié |
+| 403 | Rôle insuffisant |
+| 404 | Cours, matière, prof, classe ou salle introuvable |
+
+---
+
+### DELETE /edt/cours/\<cours_id\>
+
+Supprime définitivement un cours.
+
+**Rôles autorisés :** `administrateur`, `employé` direction.
+
+**Réponses :**
+| Code | Cas |
+|---|---|
+| 200 | `{ "message": "Cours supprimé" }` |
+| 401 | Non authentifié |
+| 403 | Rôle insuffisant |
+| 404 | Cours introuvable |
+
+---
+
+## Valeurs d'état (`etat`)
+
+| Valeur | Description |
+|---|---|
+| `planifié` | Cours prévu (défaut à la création) |
+| `en cours` | Cours actuellement en train de se dérouler |
+| `terminé` | Cours passé |
+| `annulé` | Cours annulé |


### PR DESCRIPTION
## Résumé

- Reorganisation dans `docs/api/` (auth, admin, edt)
- Correction `api/auth.md` : champ login était `username` au lieu de `email`, ajout de `POST /auth/setup-password`
- Ajout `api/admin.md` : CRUD utilisateurs, RBAC direction vs admin, flux création compte avec setup_token
- Ajout `api/edt.md` : CRUD cours, scopes automatiques par rôle, filtres GET, valeurs d'état

## Routes documentées

| Fichier | Routes |
|---|---|
| `auth.md` | POST /auth/login, POST /auth/logout, PATCH /auth/profile/password, PATCH /auth/profile/phone, POST /auth/profile/contact-direction, POST /auth/setup-password |
| `admin.md` | GET /admin/users, POST /admin/users, PATCH /admin/users/<id>, DELETE /admin/users/<id> |
| `edt.md` | GET /edt/cours, POST /edt/cours, PATCH /edt/cours/<id>, DELETE /edt/cours/<id> |